### PR TITLE
Update ubl-creditnote.xml

### DIFF
--- a/structure/syntax/ubl-creditnote.xml
+++ b/structure/syntax/ubl-creditnote.xml
@@ -1637,7 +1637,7 @@
                     <Value type="EXAMPLE">4000.00</Value> 
                 </Element>
 
-            </Element>
+
             <Element>
                 <Term>cbc:TaxAmount</Term>
                 <Name>VAT category tax amount</Name>
@@ -1710,7 +1710,7 @@
                 </Element>
             </Element>
         </Element>
-
+        </Element>
 
 
         <Element>


### PR DESCRIPTION
There is an "/element" too much in line 1640, moving the remaining <cac:taxSubTotal> elements one level too high. 
If left as is, the XML is non compliant to the EN norm.
The "/element" needs to be on line 1713

Current version of the file:
cac:TaxTotal/cbc:TaxAmount
cac:TaxTotal/cac:TaxSubtotal
cac:TaxTotal/cac:TaxSubtotal/cbc:TaxableAmount
cac:TaxTotal/cbc:TaxAmount
cac:TaxTotal/cac:TaxCategory
cac:TaxTotal/cac:TaxCategory/cbc:ID
cac:TaxTotal/cac:TaxCategory/cbc:Percent
cac:TaxTotal/cac:TaxCategory/cbc:TaxExemptionReasonCode
cac:TaxTotal/cac:TaxCategory/cbc:TaxExemptionReason
cac:TaxTotal/cac:TaxCategory/cac:TaxScheme
cac:TaxTotal/cac:TaxCategory/cac:TaxScheme/cbc:ID

Proposed change would result in:
cac:TaxTotal/cac:TaxSubtotal/cbc:TaxAmount
cac:TaxTotal/cac:TaxSubtotal/cbc:TaxAmount/@currencyID
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:ID
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:Percent
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:TaxExemptionReasonCode
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:TaxExemptionReason
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cbc:ID