### PR TITLE
Update ubl-invoice.xml

### DIFF
--- a/structure/syntax/ubl-invoice.xml
+++ b/structure/syntax/ubl-invoice.xml
@@ -1593,7 +1593,7 @@
                     </Element>
                 </Element>
             </Element>
-        </Element>
+        
 
         <Element cardinality="0..2">
             <Term>cac:TaxTotal</Term>
@@ -1723,7 +1723,7 @@
                 </Element>
             </Element>
         </Element>
-
+    </Element>
 
 
         <Element>


### PR DESCRIPTION
There is an "/element" too much in line 1569, moving the remaining cac:taxSubTotal elements one level too high.
If left as is, the XML is non compliant to the EN norm.
The "/element" needs to be on line 1726

Current version of the file:
cac:TaxTotal/cbc:TaxAmount
cac:TaxTotal/cac:TaxSubtotal
cac:TaxTotal/cac:TaxSubtotal/cbc:TaxableAmount
cac:TaxTotal/cbc:TaxAmount
cac:TaxTotal/cac:TaxCategory
cac:TaxTotal/cac:TaxCategory/cbc:ID
cac:TaxTotal/cac:TaxCategory/cbc:Percent
cac:TaxTotal/cac:TaxCategory/cbc:TaxExemptionReasonCode
cac:TaxTotal/cac:TaxCategory/cbc:TaxExemptionReason
cac:TaxTotal/cac:TaxCategory/cac:TaxScheme
cac:TaxTotal/cac:TaxCategory/cac:TaxScheme/cbc:ID

Proposed change would result in:
cac:TaxTotal/cac:TaxSubtotal/cbc:TaxAmount
cac:TaxTotal/cac:TaxSubtotal/cbc:TaxAmount/@currencyid
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:ID
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:Percent
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:TaxExemptionReasonCode
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cbc:TaxExemptionReason
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme
cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cbc:ID