### PR TITLE
Fix typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,5 +2,5 @@
 
 This repository contains the resources making up PEPPOL BIS Billing 3.0.
 
-Please use our link:https://openpeppol.atlassian.net/servicedesk/customer/portal/1[Service desk] to report any issues related to the specifiction.
+Please use our link:https://openpeppol.atlassian.net/servicedesk/customer/portal/1[Service desk] to report any issues related to the specification.
 .


### PR DESCRIPTION
While "specifiction" opens a wide world of meanings, I doubt it was the original intent. Fix the typo.