### PR TITLE
Fixed u:gln to expect GLN to be size of 13

### DIFF
--- a/guide/release-notes/main.adoc
+++ b/guide/release-notes/main.adoc
@@ -14,6 +14,8 @@ IMPORTANT: Changes in code lists are also reflected by changes in the validation
 
 :leveloffset: +1
 
+include::v3.0.9-hotfix.adoc[]
+
 include::v3.0.8.adoc[]
 
 include::v3.0.7-hotfix.adoc[]

--- a/guide/release-notes/v3.0.9-hotfix.adoc
+++ b/guide/release-notes/v3.0.9-hotfix.adoc
@@ -1,0 +1,14 @@
+= Version 3.0.9 - Hotfix
+[horizontal]
+Release date:: 2020-11-12
+
+== Changes to BIS document
+* Added VAT tax category code B to code list 5305. This code is allowed in the EN16931 for Italy only, based on the A-deviation.
+
+== Changes to support documents
+
+
+== Changes to code lists and validation artefacts
+* Correction to release notes 3.0.8, noting that version containted the latest version of the EN16931 valdiation artefacts with the changes noted in their release notes https://github.com/ConnectingEurope/eInvoicing-EN16931/releases/tag/validation-1.3.3
+
+* Applied workarounds to some Peppol national rules for broader compatilibity with transformation tools.

--- a/rules/national-examples/GR/GR-base-example-TaxRepresentative.xml
+++ b/rules/national-examples/GR/GR-base-example-TaxRepresentative.xml
@@ -14,7 +14,7 @@
     <cbc:BuyerReference>0150abc</cbc:BuyerReference>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="9933">801399030</cbc:EndpointID>            
+            <cbc:EndpointID schemeID="0088">1238764941386</cbc:EndpointID>            
             <cac:PartyIdentification>
                 <cbc:ID>155988103000</cbc:ID>
             </cac:PartyIdentification>
@@ -27,14 +27,9 @@
                 <cbc:CityName>Athens</cbc:CityName>
                 <cbc:PostalZone>163 44</cbc:PostalZone>
                 <cac:Country>
-                    <cbc:IdentificationCode>GR</cbc:IdentificationCode>
+                    <cbc:IdentificationCode>SE</cbc:IdentificationCode>
                 </cac:Country>
-            </cac:PostalAddress>
-            <cac:PartyLegalEntity>
-                <cbc:RegistrationName>SupplierOfficialName Ltd</cbc:RegistrationName>
-                <cbc:CompanyID>EL801399030</cbc:CompanyID>
-            </cac:PartyLegalEntity>
-            
+            </cac:PostalAddress>            
         </cac:Party>
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
@@ -53,7 +48,7 @@
                 <cbc:CityName>Stockholm</cbc:CityName>
                 <cbc:PostalZone>456 34</cbc:PostalZone>
                 <cac:Country>
-                    <cbc:IdentificationCode>GR</cbc:IdentificationCode>
+                    <cbc:IdentificationCode>SE</cbc:IdentificationCode>
                 </cac:Country>
             </cac:PostalAddress>
             
@@ -93,6 +88,7 @@
         </cac:Attachment>
     </cac:AdditionalDocumentReference>
     <cac:TaxRepresentativeParty>
+        
         <cac:PartyName>
             <cbc:Name>TaxRepresentative Name</cbc:Name>
         </cac:PartyName>

--- a/rules/sch/PEPPOL-EN16931-CII.sch
+++ b/rules/sch/PEPPOL-EN16931-CII.sch
@@ -37,7 +37,7 @@ This schematron uses business terms defined the CEN/EN16931-1 and is reproduced 
     <variable name="length" select="string-length($val) - 1"/>
     <variable name="digits" select="reverse(for $i in string-to-codepoints(substring($val, 0, $length + 1)) return $i - 48)"/>
     <variable name="weightedSum" select="sum(for $i in (0 to $length - 1) return $digits[$i + 1] * (1 + ((($i + 1) mod 2) * 2)))"/>
-    <value-of select="(10 - ($weightedSum mod 10)) mod 10 = number(substring($val, $length + 1, 1))"/>
+    <value-of select="string-length($val) = 13 and (10 - ($weightedSum mod 10)) mod 10 = number(substring($val, $length + 1, 1))"/>
   </function>
   <function xmlns="http://www.w3.org/1999/XSL/Transform" name="u:slack" as="xs:boolean">
     <param name="exp" as="xs:decimal"/>
@@ -175,7 +175,7 @@ This schematron uses business terms defined the CEN/EN16931-1 and is reproduced 
                 their invoice. "Dersom selger er aksjeselskap, allmennaksjeselskap eller filial av
                 utenlandsk selskap skal også ordet «Foretaksregisteret» fremgå av salgsdokumentet,
                 jf. foretaksregisterloven § 10-2."</assert>
-      <assert id="NO-R-001" test="ram:SpecifiedTaxRegistration[ram:ID/@schemeID = 'VAT']/substring(ram:ID, 1, 2)='NO' and matches(ram:SpecifiedTaxRegistration[ram:ID/@schemeID = 'VAT']/substring(ram:ID,3) , '^[0-9]{9}MVA$') 
+      <assert id="NO-R-001" test="ram:SpecifiedTaxRegistration[ram:ID/@schemeID = 'VAT']/substring(ram:ID, 1, 2)='NO' and matches(ram:SpecifiedTaxRegistration[ram:ID/@schemeID = 'VAT']/substring(ram:ID,3) , '^[0-9]{9}MVA$')
                 and u:mod11(substring(ram:SpecifiedTaxRegistration[ram:ID/@schemeID = 'VAT']/ram:ID, 3, 9)) or not(ram:SpecifiedTaxRegistration[ram:ID/@schemeID = 'VAT']/substring(ram:ID, 1, 2)='NO')" flag="fatal">For Norwegian suppliers, a VAT number MUST be the country code prefix NO followed by a valid Norwegian organization number (nine numbers) followed by the letters MVA.</assert>
     </rule>
   </pattern>
@@ -194,7 +194,7 @@ This schematron uses business terms defined the CEN/EN16931-1 and is reproduced 
                                        and number(rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge/ram:Reason &lt;= 9999)
                                       )
                               )" flag="fatal">When specifying non-VAT Taxes, Danish suppliers MUST use the SpecifiedTradeAllowanceCharge/ReasonCode="ZZZ" and the 4-digit Tax category MUST be specified as Reason</assert>
-      <assert id="DK-R-013" test="not(($DKCustomerCountry = 'DK') and 
+      <assert id="DK-R-013" test="not(($DKCustomerCountry = 'DK') and
                                   ( ((boolean(rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:GlobalID))
                                      and (normalize-space(rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:GlobalID/@schemeID) = ''))
                                    or

--- a/rules/sch/PEPPOL-EN16931-UBL.sch
+++ b/rules/sch/PEPPOL-EN16931-UBL.sch
@@ -43,7 +43,7 @@ This schematron uses business terms defined the CEN/EN16931-1 and is reproduced 
 		<variable name="length" select="string-length($val) - 1"/>
 		<variable name="digits" select="reverse(for $i in string-to-codepoints(substring($val, 0, $length + 1)) return $i - 48)"/>
 		<variable name="weightedSum" select="sum(for $i in (0 to $length - 1) return $digits[$i + 1] * (1 + ((($i + 1) mod 2) * 2)))"/>
-		<value-of select="(10 - ($weightedSum mod 10)) mod 10 = number(substring($val, $length + 1, 1))"/>
+		<value-of select="string-length($val) = 13 and (10 - ($weightedSum mod 10)) mod 10 = number(substring($val, $length + 1, 1))"/>
 	</function>
 	<function xmlns="http://www.w3.org/1999/XSL/Transform" name="u:slack" as="xs:boolean">
 		<param name="exp" as="xs:decimal"/>
@@ -62,7 +62,7 @@ This schematron uses business terms defined the CEN/EN16931-1 and is reproduced 
 	<pattern>
 		<rule context="//*[not(*) and not(normalize-space())]">
 			<assert id="PEPPOL-EN16931-R008" test="false()" flag="fatal">Document MUST not contain empty elements.</assert>
-		</rule> 
+		</rule>
 	</pattern>
 	<!--
     Transaction rules
@@ -376,28 +376,28 @@ This schematron uses business terms defined the CEN/EN16931-1 and is reproduced 
 		<let name="dateRegExp" value="'^(0?[1-9]|[12][0-9]|3[01])[-\\/ ]?(0?[1-9]|1[0-2])[-\\/ ]?(19|20)[0-9]{2}'"/>
 		<let name="greekDocumentType" value="tokenize('1.1 1.2 1.3 1.4 1.5 1.6 2.1 2.2 2.3 2.4 3.1 3.2 4 5.1 5.2 6.1 6.2 7.1 8.1 8.2 11.1 11.2 11.3 11.4 11.5','\s')"/>
 	  <let name="tokenizedUblIssueDate" value="tokenize(/*/cbc:IssueDate,'-')"/>
-	  
+
 
 		<!-- Invoice ID -->
 	  <rule context="/ubl-invoice:Invoice/cbc:ID[$isGreekSender] | /ubl-creditnote:CreditNote/cbc:ID[$isGreekSender]">
 			<let name="IdSegments" value="tokenize(.,'\|')"/>
 			<assert id="GR-R-001-1" test="count($IdSegments) = 6" flag="fatal"> When the Supplier is Greek, the Invoice Id should consist of 6 segments</assert>
-			<assert id="GR-R-001-2" test="string-length(normalize-space($IdSegments[1])) = 9 
+			<assert id="GR-R-001-2" test="string-length(normalize-space($IdSegments[1])) = 9
 			                              and u:TinVerification($IdSegments[1])
 			                              and ($IdSegments[1] = /*/cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 3, 9)
-			                              or $IdSegments[1] = /*/cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 3, 9) )" 
+			                              or $IdSegments[1] = /*/cac:TaxRepresentativeParty/cac:PartyTaxScheme[cac:TaxScheme/cbc:ID = 'VAT']/substring(cbc:CompanyID, 3, 9) )"
 			                              flag="fatal">When the Supplier is Greek, the Invoice Id first segment must be a valid TIN Number and match either the Supplier's or the Tax Representative's Tin Number</assert>
 		  <let name="tokenizedIdDate" value="tokenize($IdSegments[2],'/')"/>
-		  <assert id="GR-R-001-3" test="string-length(normalize-space($IdSegments[2]))>0 
+		  <assert id="GR-R-001-3" test="string-length(normalize-space($IdSegments[2]))>0
 			                              and matches($IdSegments[2],$dateRegExp)
-			                              and ($tokenizedIdDate[1] = $tokenizedUblIssueDate[3] 
+			                              and ($tokenizedIdDate[1] = $tokenizedUblIssueDate[3]
 			                                and $tokenizedIdDate[2] = $tokenizedUblIssueDate[2]
 			                                and $tokenizedIdDate[3] = $tokenizedUblIssueDate[1])" flag="fatal">When the Supplier is Greek, the Invoice Id second segment must be a valid Date that matches the invoice Issue Date</assert>
 			<assert id="GR-R-001-4" test="string-length(normalize-space($IdSegments[3]))>0 and string(number($IdSegments[3])) != 'NaN' and xs:integer($IdSegments[3]) >= 0" flag="fatal">When Supplier is Greek, the Invoice Id third segment must be a positive integer</assert>
 			<assert id="GR-R-001-5" test="string-length(normalize-space($IdSegments[4]))>0 and (some $c in $greekDocumentType satisfies $IdSegments[4] = $c)" flag="fatal">When Supplier is Greek, the Invoice Id in the fourth segment must be a valid greek document type</assert>
 			<assert id="GR-R-001-6" test="string-length($IdSegments[5]) > 0 " flag="fatal">When Supplier is Greek, the Invoice Id fifth segment must not be empty</assert>
 			<assert id="GR-R-001-7" test="string-length($IdSegments[6]) > 0 " flag="fatal">When Supplier is Greek, the Invoice Id sixth segment must not be empty</assert>
-		  
+
 		</rule>
 
 		<rule context="cac:AccountingSupplierParty[$isGreekSender]/cac:Party">

--- a/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R040.xml
+++ b/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R040.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-cii">
+  <assert>
+    <scope>PEPPOL-COMMON-R040</scope>
+  </assert>
+
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R040</success>
+    </assert>
+        <rsm:CrossIndustryInvoice
+      xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+      xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+      xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0088">9429041098400</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R040</error>
+    </assert>
+        <rsm:CrossIndustryInvoice
+      xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+      xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+      xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0088">9429041098401</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <description>Expect GLN to have 13 digits</description>
+      <error>PEPPOL-COMMON-R040</error>
+    </assert>
+        <rsm:CrossIndustryInvoice
+      xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+      xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+      xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0088">00</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-GR/GR_Validation_GRR007.xml
+++ b/rules/unit-UBL-GR/GR_Validation_GRR007.xml
@@ -21,7 +21,7 @@
                 <cac:Party>
                     <cac:PostalAddress>
                         <cac:Country>
-                            <cbc:IdentificationCode>GR</cbc:IdentificationCode>
+                            <cbc:IdentificationCode>SE</cbc:IdentificationCode>
                         </cac:Country>
                     </cac:PostalAddress>
                  

--- a/rules/unit-UBL-GR/GR_Validation_GRR009.xml
+++ b/rules/unit-UBL-GR/GR_Validation_GRR009.xml
@@ -70,5 +70,41 @@
             </cac:AccountingSupplierParty>
         </Invoice>
     </test>
+
+    <test>
+        <assert>
+            <success>GR-R-009</success>
+        </assert>
+        <Invoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 "
+            xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <cbc:ID>061828591|01/10/2010|0|1.1|0|1</cbc:ID>
+            <cac:AccountingSupplierParty>
+                <cac:Party>
+                    <cbc:EndpointID schemeID="0088">1238764941386</cbc:EndpointID>
+                    <cac:PostalAddress>
+                        <cac:Country>
+                            <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                        </cac:Country>
+                    </cac:PostalAddress>
+                </cac:Party>
+            </cac:AccountingSupplierParty>
+            <cac:TaxRepresentativeParty>
+                <cac:PostalAddress>
+                    <cac:Country>
+                        <cbc:IdentificationCode>GR</cbc:IdentificationCode>
+                    </cac:Country>
+                </cac:PostalAddress>
+                <cac:PartyTaxScheme>
+                    <cbc:CompanyID>EL061828591</cbc:CompanyID>
+                    <cac:TaxScheme>
+                        <cbc:ID>VAT</cbc:ID>
+                    </cac:TaxScheme>
+                </cac:PartyTaxScheme>
+            </cac:TaxRepresentativeParty>
+       </Invoice>
+    </test>
     
 </testSet>

--- a/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R040.xml
+++ b/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R040.xml
@@ -31,4 +31,19 @@
             </cac:AccountingCustomerParty>
         </Invoice>
     </test>
+    <test>
+        <assert>
+            <description>Expect GLN to have 13 digits</description>
+            <error>PEPPOL-COMMON-R040</error>
+        </assert>
+        <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                 xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                 xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+            <cac:AccountingCustomerParty>
+                <cac:Party>
+                    <cbc:EndpointID schemeID="0088">00</cbc:EndpointID>
+                </cac:Party>
+            </cac:AccountingCustomerParty>
+        </Invoice>
+    </test>
 </testSet>

--- a/structure/codelist/UNCL5305.xml
+++ b/structure/codelist/UNCL5305.xml
@@ -73,4 +73,10 @@
             the transfer of immovable property located in the cities
             of Ceuta and Melilla.</Description>
     </Code>
+	
+	<Code>
+        <Id>B</Id>
+        <Name>Transferred (VAT), In Italy</Name>
+        <Description>VAT not to be paid to the issuer of the invoice but directly to relevant tax authority. This code 		is allowed in the EN 16931 for Italy only based on the Italian A-deviation.</Description>
+    </Code>
 </CodeList>


### PR DESCRIPTION
Hi!

There seems to be issue with rule PEPPOL-COMMON-R040 not catching invalid GLN numbers. For example "00" and "14977" seems to pass the validation.

I hope my fix and pull request is useful for you!

With best regards,
Jussi