### PR TITLE
Fix a typo

### DIFF
--- a/guide/syntax/roles.adoc
+++ b/guide/syntax/roles.adoc
@@ -19,7 +19,7 @@ include::{snippet-dir}/Snippet-full.xml[tags=seller]
 
 Buyer is mandatory information and provided in element `cac:AccountingCustomerParty`
 
-.UBL example ofbuyer information
+.UBL example of buyer information
 [source, xml, indent=0]
 ----
 include::{snippet-dir}/Snippet-full.xml[tags=buyer]


### PR DESCRIPTION
This PR should fix a small typo in UBL example description of "10.1.2. Buyer (AccountingCustomerParty)".
