### PR TITLE
Normalize spaces in validation tests

### DIFF
--- a/tools/xquery/rules_asciidoc_peppol.xquery
+++ b/tools/xquery/rules_asciidoc_peppol.xquery
@@ -10,7 +10,7 @@ $x in //iso:pattern/iso:rule/iso:assert
 let $RuleId := string($x/@id)
 let $rule := replace(normalize-space(string($x/../@context)), '\|', '\\|')
 let $flag := string($x/@flag)
-let $assert := string($x/@test)
+let $assert := normalize-space(string($x/@test))
 let $tekst := normalize-space($x/text())
 
 where starts-with($x/@id, 'PEPPOL')


### PR DESCRIPTION
This PR add `normalize-space` to extracted validation test strings,  and should fix test cells in tables, at least, "Table18. PEPPOL transaction business rules" in "15. Transaction validation rules"

## Before

<img width="929" alt="Screen Shot 2020-12-02 at 16 36 32" src="https://user-images.githubusercontent.com/34205/100842757-a7e17a00-34bc-11eb-84e7-0888ce078d36.png">

## After

<img width="929" alt="Screen Shot 2020-12-02 at 16 36 46" src="https://user-images.githubusercontent.com/34205/100842771-aca62e00-34bc-11eb-80be-3f94c6d9259b.png">
