### PR TITLE
Fix NO examples to be true to rule UBL-CR-679

### DIFF
--- a/rules/national-examples/NO/Norwegian-example-1.xml
+++ b/rules/national-examples/NO/Norwegian-example-1.xml
@@ -419,7 +419,7 @@
 			</cac:CommodityClassification>
 			<cac:ClassifiedTaxCategory>
 				<!-- 43 -->
-				<cbc:ID schemeID="UNCL5305">S</cbc:ID>
+				<cbc:ID>S</cbc:ID>
 				<cbc:Percent>15</cbc:Percent>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
@@ -459,7 +459,7 @@
 			</cac:CommodityClassification>
 			<cac:ClassifiedTaxCategory>
 				<!-- 43 -->
-				<cbc:ID schemeID="UNCL5305">S</cbc:ID>
+				<cbc:ID>S</cbc:ID>
 				<cbc:Percent>15</cbc:Percent>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
@@ -504,7 +504,7 @@
 			</cac:CommodityClassification>
 			<cac:ClassifiedTaxCategory>
 				<!-- 51 -->
-				<cbc:ID schemeID="UNCL5305">E</cbc:ID>
+				<cbc:ID>E</cbc:ID>
 				<cbc:Percent>0</cbc:Percent>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
@@ -544,7 +544,7 @@
 			</cac:CommodityClassification>
 			<cac:ClassifiedTaxCategory>
 				<!-- 51 -->
-				<cbc:ID schemeID="UNCL5305">S</cbc:ID>
+				<cbc:ID>S</cbc:ID>
 				<cbc:Percent>25</cbc:Percent>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>


### PR DESCRIPTION
Rule `UBL-CR-679` states:
`not(//cac:ClassifiedTaxCategory/cbc:ID/@schemeID)`

I find it somewhat confusing when the national examples warns of incorrect content with the rules that apply and are made mandatory. I guess this in practice has no implications other than confusion and distractions.