### PR TITLE
Add country-specific rules for the Netherlands

### DIFF
--- a/rules/sch/PEPPOL-EN16931-CII.sch
+++ b/rules/sch/PEPPOL-EN16931-CII.sch
@@ -302,6 +302,65 @@ This schematron uses business terms defined the CEN/EN16931-1 and is reproduced 
       <assert id="SE-R-012" test="false()" flag="warning">For domestic transactions between Swedish trading partners, credit transfer should be indicated by PaymentMeansCode=”30”</assert>
     </rule>
   </pattern>
+  <!-- NETHERLANDS -->
+  <pattern>
+  <rule context="/rsm:CrossIndustryInvoice/rsm:ExchangedDocument[some $code in tokenize('81 83 381 396 532', '\s') satisfies normalize-space(ram:TypeCode) = $code][$supplierCountry = 'NL']">
+    <!-- Original rule in NLCIUS: BR-NL-9 -->
+    <assert id="NL-R-001" test="//ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument/ram:IssuerAssignedID" flag="fatal">[NL-R-001] For suppliers in the Netherlands, if the document is a creditnote, the document MUST contain an invoice reference (ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument/ram:IssuerAssignedID)</assert>
+  </rule>
+
+    <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:PostalTradeAddress[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-3 -->
+      <assert id="NL-R-002" test="ram:LineOne and ram:CityName and ram:PostcodeCode" flag="fatal">[NL-R-002] For suppliers in the Netherlands the supplier's address (ram:SellerTradeParty/ram:PostalTradeAddress) MUST contain street name (ram:LineOne), city (ram:CityName) and post code (ram:PostcodeCode)</assert>
+    </rule>
+
+    <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedLegalOrganization/ram:ID[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-1 -->
+      <assert id="NL-R-003" test="(contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0106 ') or contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0190 ')) and (normalize-space(.) != '')" flag="fatal">[NL-R-003] For suppliers in the Netherlands, the legal entity identifier MUST be either a KVK or OIN number (schemeID 0106 or 0190)</assert>
+    </rule>
+
+    <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:PostalTradeAddress[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-4 -->
+      <assert id="NL-R-004" test="ram:CountryID != 'NL' or (ram:LineOne and ram:CityName and ram:PostcodeCode)" flag="fatal">[NL-R-004] For suppliers in the Netherlands, if the customer is in the Netherlands, the customer address (ram:BuyerTradeParty/ram:PostalTradeAddress) MUST contain street name (ram:LineOne), city (ram:CityName) and post code (ram:PostcodeCode)</assert>
+    </rule>
+
+    <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:SpecifiedLegalOrganization/ram:ID[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-10 -->
+      <assert id="NL-R-005" test="
+          (not(../../ram:PostalTradeAddress/ram:CountryID = 'NL')
+           or (
+           contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0106 ')
+           or
+           contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0190 ')
+          ) and (normalize-space(.) != ''))
+      " flag="fatal">[NL-R-005] For suppliers in the Netherlands, if the customer is in the Netherlands, the customer's legal entity identifier MUST be either a KVK or OIN number (schemeID 0106 or 0190)</assert>
+    </rule>
+
+    <rule context="rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTaxRepresentativeTradeParty/ram:PostalTradeAddress[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-5 -->
+      <assert id="NL-R-006" test="ram:CountryID != 'NL' or (ram:LineOne and ram:CityName and ram:PostcodeCode)" flag="fatal">[NL-R-006] For suppliers in the Netherlands, if the fiscal representative is in the Netherlands, the representative's address (ram:SellerTaxRepresentativeTradeParty/ram:PostalTradeAddress) MUST contain street name (ram:LineOne), city (ram:CityName) and post code (ram:PostcodeCode)</assert>
+    </rule>
+
+    <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementHeaderMonetarySummation[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-11 -->
+      <assert id="NL-R-007" test="xs:decimal(ram:DuePayableAmount) &lt;= 0.0 or (/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans)" flag="fatal">[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (ram:SpecifiedTradeSettlementPaymentMeans) if the payment is from customer to supplier</assert>
+    </rule>
+
+    <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-12 -->
+      <assert id="NL-R-008" test="normalize-space(ram:TypeCode) = '30' or
+                normalize-space(ram:TypeCode) = '48' or
+                normalize-space(ram:TypeCode) = '49' or
+                normalize-space(ram:TypeCode) = '57' or
+                normalize-space(ram:TypeCode) = '58' or
+                normalize-space(ram:TypeCode) = '59'" flag="fatal">[NL-R-008] For suppliers in the Netherlands, the payment means code (ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode) MUST be one of 30, 48, 49, 57, 58 or 59</assert>
+    </rule>
+
+    <rule context="rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:LineID[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-13 -->
+      <assert id="NL-R-009" test="exists(/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID)" flag="fatal">[NL-R-009] For suppliers in the Netherlands, if an order line reference (ram:BuyerOrderReferencedDocument/ram:LineID) is used, there must be an order reference on the document level (rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID)</assert>
+    </rule>
+  </pattern>
   <!-- Restricted code lists and formatting -->
   <pattern>
     <let name="ISO3166" value="tokenize('AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS YE YT ZA ZM ZW', '\s')"/>

--- a/rules/sch/PEPPOL-EN16931-UBL.sch
+++ b/rules/sch/PEPPOL-EN16931-UBL.sch
@@ -537,7 +537,69 @@ This schematron uses business terms defined the CEN/EN16931-1 and is reproduced 
 		
 		</rule>
 	</pattern>
-  
+
+  <!-- NETHERLANDS -->
+  <pattern>
+    <rule context="cbc:CreditNoteTypeCode[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-9
+	   This rule has changed: since 384 is not an allowed invoice type code in PEPPOL BIS,
+	   this rule now only applies to credit notes
+      -->
+      <assert id="NL-R-001" test="/*/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID" flag="fatal">[NL-R-001] For suppliers in the Netherlands, if the document is a creditnote, the document MUST contain an invoice reference (cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID)</assert>
+    </rule>
+    <rule context="cac:AccountingSupplierParty/cac:Party/cac:PostalAddress[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-3 -->
+      <assert id="NL-R-002" test="cbc:StreetName and
+		      cbc:CityName and
+		      cbc:PostalZone" flag="fatal">[NL-R-002] For suppliers in the Netherlands the supplier's address (cac:AccountingSupplierParty/cac:Party/cac:PostalAddress) MUST contain street name (cbc:StreetName), city (cbc:CityName) and post code (cbc:PostalZone)</assert>
+    </rule>
+    <rule context="cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-1 -->
+      <assert id="NL-R-003" test="(contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0106 ') or contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0190 ')) and (normalize-space(.) != '')" flag="fatal">[NL-R-003] For suppliers in the Netherlands, the legal entity identifier MUST be either a KVK or OIN number (schemeID 0106 or 0190)</assert>
+    </rule>
+    <rule context="cac:AccountingCustomerParty/cac:Party/cac:PostalAddress[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-4 -->
+      <assert id="NL-R-004" test="cac:Country/cbc:IdentificationCode != 'NL' or (
+		      cbc:StreetName and
+		      cbc:CityName and
+		      cbc:PostalZone)" flag="fatal">[NL-R-004] For suppliers in the Netherlands, if the customer is in the Netherlands, the customer address (cac:AccountingCustomerParty/cac:Party/cac:PostalAddress) MUST contain the street name (cbc:StreetName), the city (cbc:CityName) and post code (cbc:PostalZone)</assert>
+    </rule>
+    <rule context="cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-10 -->
+      <assert id="NL-R-005" test="
+	  (not(//cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode = 'NL')
+	   or (
+	   contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0106 ')
+	   or
+	   contains(concat(' ', string-join(@schemeID, ' '), ' '), ' 0190 ')
+	  ) and (normalize-space(.) != ''))
+      " flag="fatal">[NL-R-005] For suppliers in the Netherlands, if the customer is in the Netherlands, the customer's legal entity identifier MUST be either a KVK or OIN number (schemeID 0106 or 0190)</assert>
+    </rule>
+    <rule context="cac:TaxRepresentativeParty/cac:PostalAddress[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-5 -->
+      <assert id="NL-R-006" test="(cac:Country/cbc:IdentificationCode != 'NL') or
+		      (cbc:StreetName and
+		       cbc:CityName and
+		       cbc:PostalZone)" flag="fatal">[NL-R-006] For suppliers in the Netherlands, if the fiscal representative is in the Netherlands, the representative's address (cac:TaxRepresentativeParty/cac:PostalAddress) MUST contain street name (cbc:StreetName), city (cbc:CityName) and post code (cbc:PostalZone)</assert>
+    </rule>
+    <rule context="cac:LegalMonetaryTotal[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-11 -->
+      <assert id="NL-R-007" test="xs:decimal(cbc:PayableAmount) &lt;= 0.0 or (//cac:PaymentMeans)" flag="fatal">[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (cac:PaymentMeans) if the payment is from customer to supplier</assert>
+    </rule>
+    <rule context="cac:PaymentMeans[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-12 -->
+      <assert id="NL-R-008" test="normalize-space(cbc:PaymentMeansCode) = '30' or
+		normalize-space(cbc:PaymentMeansCode) = '48' or
+		normalize-space(cbc:PaymentMeansCode) = '49' or
+		normalize-space(cbc:PaymentMeansCode) = '57' or
+		normalize-space(cbc:PaymentMeansCode) = '58' or
+		normalize-space(cbc:PaymentMeansCode) = '59'" flag="fatal">[NL-R-008] For suppliers in the Netherlands, the payment means code (cac:PaymentMeans/cbc:PaymentMeansCode) MUST be one of 30, 48, 49, 57, 58 or 59</assert>
+    </rule>
+    <rule context="cac:OrderLineReference/cbc:LineID[$supplierCountry = 'NL']">
+      <!-- Original rule in NLCIUS: BR-NL-13 -->
+      <assert id="NL-R-009" test="exists(/*/cac:OrderReference/cbc:ID)" flag="fatal">[NL-R-009] For suppliers in the Netherlands, if an order line reference (cac:OrderLineReference/cbc:LineID) is used, there must be an order reference on the document level (cac:OrderReference/cbc:ID)</assert>
+    </rule>
+  </pattern>
   <!-- Restricted code lists and formatting -->
   <pattern>
     <let name="ISO3166" value="tokenize('AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS YE YT ZA ZM ZW 1A XI', '\s')"/>

--- a/rules/unit-CII-NL/NL-R-001.xml
+++ b/rules/unit-CII-NL/NL-R-001.xml
@@ -1,0 +1,610 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, if the document is a creditnote, the document MUST contain an invoice reference (ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument/ram:IssuerAssignedID)</description>
+    <scope>NL-R-001</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-001</success>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+
+        </ram:ApplicableHeaderTradeSettlement>
+
+        </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <success>NL-R-001</success>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>381</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+
+          <ram:InvoiceReferencedDocument>
+            <ram:IssuerAssignedID>12345</ram:IssuerAssignedID>
+          </ram:InvoiceReferencedDocument>
+
+        </ram:ApplicableHeaderTradeSettlement>
+
+        </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-001</error>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>381</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+
+        </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-CII-NL/NL-R-002.xml
+++ b/rules/unit-CII-NL/NL-R-002.xml
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands the supplier's address (ram:SellerTradeParty/ram:PostalTradeAddress) MUST contain street name (ram:LineOne), city (ram:CityName) and post code (ram:PostcodeCode)</description>
+    <scope>NL-R-002</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-002</success>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>1234567</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:BANKGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>12345678</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:PLUSGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-002</error>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>1234567</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:BANKGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>12345678</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:PLUSGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-CII-NL/NL-R-003.xml
+++ b/rules/unit-CII-NL/NL-R-003.xml
@@ -1,0 +1,439 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, the legal entity identifier MUST be either a KVK or OIN number (schemeID 0106 or 0190)</description>
+    <scope>NL-R-003</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-003</success>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0190">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>1234567</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:BANKGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>12345678</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:PLUSGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-003</error>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0191">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>1234567</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:BANKGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>12345678</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:PLUSGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-CII-NL/NL-R-004.xml
+++ b/rules/unit-CII-NL/NL-R-004.xml
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, if the customer is in the Netherlands, the customer address (ram:BuyerTradeParty/ram:PostalTradeAddress) MUST contain street name (ram:LineOne), city (ram:CityName) and post code (ram:PostcodeCode)</description>
+    <scope>NL-R-004</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-004</success>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>1234567</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:BANKGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>12345678</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:PLUSGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-004</error>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>1234567</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:BANKGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>12345678</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:PLUSGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-CII-NL/NL-R-005.xml
+++ b/rules/unit-CII-NL/NL-R-005.xml
@@ -1,0 +1,445 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, if the customer is in the Netherlands, the customer's legal entity identifier MUST be either a KVK or OIN number (schemeID 0106 or 0190)</description>
+    <scope>NL-R-005</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-005</success>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0190">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>1234567</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:BANKGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>12345678</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:PLUSGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-005</error>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0191">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>1234567</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:BANKGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>12345678</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:PLUSGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-CII-NL/NL-R-006.xml
+++ b/rules/unit-CII-NL/NL-R-006.xml
@@ -1,0 +1,464 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, if the fiscal representative is in the Netherlands, the representative's address (ram:SellerTaxRepresentativeTradeParty/ram:PostalTradeAddress) MUST contain street name (ram:LineOne), city (ram:CityName) and post code (ram:PostcodeCode)</description>
+    <scope>NL-R-006</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-006</success>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+
+          <ram:SellerTaxRepresentativeTradeParty>
+            <ram:Name>Tax Inc.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>2211CC</ram:PostcodeCode>
+              <ram:LineOne>IRStreet</ram:LineOne>
+              <ram:CityName>Vattown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL22222222B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTaxRepresentativeTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>1234567</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:BANKGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>12345678</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:PLUSGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-006</error>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+
+          <ram:SellerTaxRepresentativeTradeParty>
+            <ram:Name>Tax Inc.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>2211CC</ram:PostcodeCode>
+              <ram:CityName>Vattown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL22222222B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTaxRepresentativeTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>1234567</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:BANKGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>12345678</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>SE:PLUSGIRO</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-CII-NL/NL-R-007.xml
+++ b/rules/unit-CII-NL/NL-R-007.xml
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, the supplier MUST provide a means of payment (ram:SpecifiedTradeSettlementPaymentMeans) if the payment is from customer to supplier</description>
+    <scope>NL-R-007</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-007</success>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-007</error>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-CII-NL/NL-R-008.xml
+++ b/rules/unit-CII-NL/NL-R-008.xml
@@ -1,0 +1,404 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, the payment means code (ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode) MUST be one of 30, 48, 49, 57, 58 or 59
+</description>
+    <scope>NL-R-008</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-008</success>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-008</error>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>31</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-CII-NL/NL-R-009.xml
+++ b/rules/unit-CII-NL/NL-R-009.xml
@@ -1,0 +1,414 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, if an order line reference (ram:BuyerOrderReferencedCIReferencedDocument/ram:LineID) is used, there must be an order reference on the document level (rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID</description>
+    <scope>NL-R-009</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-009</success>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:BuyerOrderReferencedDocument>
+              <ram:LineID>1</ram:LineID>
+            </ram:BuyerOrderReferencedDocument>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+
+          <ram:BuyerOrderReferencedDocument>
+            <ram:IssuerAssignedID>11244</ram:IssuerAssignedID>
+          </ram:BuyerOrderReferencedDocument>
+
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-009</error>
+    </assert>
+    <rsm:CrossIndustryInvoice
+     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+
+      <rsm:ExchangedDocument>
+        <ram:ID>12345</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20210101</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+
+      <rsm:SupplyChainTradeTransaction>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Example files</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:BuyerOrderReferencedDocument>
+              <ram:LineID>1</ram:LineID>
+            </ram:BuyerOrderReferencedDocument>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>25</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">8</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>200</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Document holder</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>123_reference</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Seller Inc.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">1234567890</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet</ram:LineOne>
+              <ram:CityName>Salestown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyers B.V.</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>4321BB</ram:PostcodeCode>
+              <ram:LineOne>BuyerStreet</ram:LineOne>
+              <ram:CityName>Buytown</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:Name>Trade Party</ram:Name>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:ProprietaryID>123456</ram:ProprietaryID>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+              <ram:BICID>BANKSBIC</ram:BICID>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>63</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Repeat customer discount</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>300</ram:BasisAmount>
+            <ram:ActualAmount>30</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>300</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>30</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>300</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">63</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>363</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>363</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-NL/NL-R-001.xml
+++ b/rules/unit-UBL-NL/NL-R-001.xml
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, if the document is a creditnote, the document MUST contain an invoice reference</description>
+    <scope>NL-R-001</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-001</success>
+    </assert>
+    <doc:CreditNote xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:nl-cbc="urn:digi-inkoop:ubl:2.0:NL:1.6:UBL-NL-CommonBasicComponents-2" xmlns:seef="urn:www.energie-efactuur.nl:profile:invoice:ver1.0" xmlns:seef2="urn:www.energie-efactuur.nl:profile:invoice:ver2.0" xmlns:seef3="urn:www.energie-efactuur.nl:profile:invoice:ver3.0" xmlns:setu="urn:ns.setu.nl:setu:invoice:extension:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>Invoice number</cbc:ID>
+      <cbc:IssueDate>2021-01-01</cbc:IssueDate>
+      <cbc:CreditNoteTypeCode>381</cbc:CreditNoteTypeCode>
+      <cbc:Note>This is an example note</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:AccountingCost>Buyer accounting reference</cbc:AccountingCost>
+      <cbc:BuyerReference>Buyer reference for internal routing purposes</cbc:BuyerReference>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2020-10-01</cbc:StartDate>
+        <cbc:EndDate>2020-10-31</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>This is a purchaseordernumber (inkoopordernummer)</cbc:ID>
+      </cac:OrderReference>
+      <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+          <cbc:ID>46656</cbc:ID>
+        </cac:InvoiceDocumentReference>
+      </cac:BillingReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Supplier Name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Supplier StreetName</cbc:StreetName>
+            <cbc:AdditionalStreetName>1</cbc:AdditionalStreetName>
+            <cbc:CityName>Supplier CityName</cbc:CityName>
+            <cbc:PostalZone>Supplier PostCode</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID schemeID="UN/ECE 5153">VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Supplier Name</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer Name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Customer StreetName</cbc:StreetName>
+            <cbc:CityName>Customer CityName</cbc:CityName>
+            <cbc:PostalZone>Customer Postcode</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer Name</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>Payment ID</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>IBAN number</cbc:ID>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>1 cent charge</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">0.01</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0.0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeID="UN/ECE 5153">VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">6.75</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">32.15</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">6.75</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.0</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID schemeID="UN/ECE 5153">VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">0.01</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.0</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID schemeID="UN/ECE 5153">VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">32.15</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">32.16</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">38.91</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">0.01</cbc:ChargeTotalAmount>
+        <cbc:PayableAmount currencyID="EUR">38.91</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:CreditNoteLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:CreditedQuantity unitCode="C62">1.00</cbc:CreditedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">32.15</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Description>Long product / service description</cbc:Description>
+          <cbc:Name>Main product / service description</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.0</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID schemeID="UN/ECE 5153">VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">32.15</cbc:PriceAmount>
+          <cbc:BaseQuantity unitCode="C62">1.0</cbc:BaseQuantity>
+        </cac:Price>
+      </cac:CreditNoteLine>
+    </doc:CreditNote>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-001</error>
+    </assert>
+    <doc:CreditNote xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:nl-cbc="urn:digi-inkoop:ubl:2.0:NL:1.6:UBL-NL-CommonBasicComponents-2" xmlns:seef="urn:www.energie-efactuur.nl:profile:invoice:ver1.0" xmlns:seef2="urn:www.energie-efactuur.nl:profile:invoice:ver2.0" xmlns:seef3="urn:www.energie-efactuur.nl:profile:invoice:ver3.0" xmlns:setu="urn:ns.setu.nl:setu:invoice:extension:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>Invoice number</cbc:ID>
+      <cbc:IssueDate>2021-01-01</cbc:IssueDate>
+      <cbc:CreditNoteTypeCode>381</cbc:CreditNoteTypeCode>
+      <cbc:Note>This is an example note</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:AccountingCost>Buyer accounting reference</cbc:AccountingCost>
+      <cbc:BuyerReference>Buyer reference for internal routing purposes</cbc:BuyerReference>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2020-10-01</cbc:StartDate>
+        <cbc:EndDate>2020-10-31</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>This is a purchaseordernumber (inkoopordernummer)</cbc:ID>
+      </cac:OrderReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Supplier Name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Supplier StreetName</cbc:StreetName>
+            <cbc:AdditionalStreetName>1</cbc:AdditionalStreetName>
+            <cbc:CityName>Supplier CityName</cbc:CityName>
+            <cbc:PostalZone>Supplier PostCode</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID schemeID="UN/ECE 5153">VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Supplier Name</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer Name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Customer StreetName</cbc:StreetName>
+            <cbc:CityName>Customer CityName</cbc:CityName>
+            <cbc:PostalZone>Customer Postcode</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer Name</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>Payment ID</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>IBAN number</cbc:ID>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>1 cent charge</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">0.01</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0.0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeID="UN/ECE 5153">VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">6.75</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">32.15</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">6.75</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.0</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID schemeID="UN/ECE 5153">VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">0.01</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.0</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID schemeID="UN/ECE 5153">VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">32.15</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">32.16</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">38.91</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">0.01</cbc:ChargeTotalAmount>
+        <cbc:PayableAmount currencyID="EUR">38.91</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:CreditNoteLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:CreditedQuantity unitCode="C62">1.00</cbc:CreditedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">32.15</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Description>Long product / service description</cbc:Description>
+          <cbc:Name>Main product / service description</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.0</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID schemeID="UN/ECE 5153">VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">32.15</cbc:PriceAmount>
+          <cbc:BaseQuantity unitCode="C62">1.0</cbc:BaseQuantity>
+        </cac:Price>
+      </cac:CreditNoteLine>
+    </doc:CreditNote>
+  </test>
+</testSet>

--- a/rules/unit-UBL-NL/NL-R-002.xml
+++ b/rules/unit-UBL-NL/NL-R-002.xml
@@ -1,0 +1,568 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+    <description>For suppliers in the Netherlands the supplier's address (cac:AccountingSupplierParty/cac:Party/cac:PostalAddress) MUST contain street name (cbc:StreetName), city (cbc:CityName) and post code (cbc:PostalZone)</description>
+    <scope>NL-R-002</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-002</success>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 1</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-002</error>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cac:Country>
+              <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-NL/NL-R-003.xml
+++ b/rules/unit-UBL-NL/NL-R-003.xml
@@ -1,0 +1,571 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, the legal entity identifier MUST be either a KVK or OIN number (schemeID 0106 or 0190)</description>
+    <scope>NL-R-003</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-003</success>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-003</error>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0102">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-NL/NL-R-004.xml
+++ b/rules/unit-UBL-NL/NL-R-004.xml
@@ -1,0 +1,568 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, if the customer is in the Netherlands, the customer address (cac:AccountingCustomerParty/cac:Party/cac:PostalAddress) MUST contain the street name (cbc:StreetName), the city (cbc:CityName) and post code (cbc:PostalZone)</description>
+    <scope>NL-R-004</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-004</success>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-004</error>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-NL/NL-R-005.xml
+++ b/rules/unit-UBL-NL/NL-R-005.xml
@@ -1,0 +1,571 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, if the customer is in the Netherlands, the customer's legal entity identifier MUST be either a KVK or OIN number (schemeID 0106 or 0190)</description>
+    <scope>NL-R-005</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-005</success>
+    </assert>
+    <doc:Invoice xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="attachment.PDF">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-005</error>
+    </assert>
+    <doc:Invoice xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="attachment.PDF">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0102">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-NL/NL-R-006.xml
+++ b/rules/unit-UBL-NL/NL-R-006.xml
@@ -1,0 +1,606 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, if the fiscal representative is in the Netherlands, the representative's address (cac:TaxRepresentativeParty/cac:PostalAddress) MUST contain street name (cbc:StreetName), city (cbc:CityName) and post code (cbc:PostalZone)</description>
+    <scope>NL-R-006</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-006</success>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:TaxRepresentativeParty>
+        <cac:PartyName>
+          <cbc:Name>Fiscaal vertegenwoordiger</cbc:Name>
+        </cac:PartyName>
+        <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+        </cac:PostalAddress>
+        <cac:PartyTaxScheme>
+          <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:PartyTaxScheme>
+      </cac:TaxRepresentativeParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-006</error>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:TaxRepresentativeParty>
+        <cac:PartyName>
+          <cbc:Name>Fiscaal vertegenwoordiger</cbc:Name>
+        </cac:PartyName>
+        <cac:PostalAddress>
+          <cac:Country>
+            <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+          </cac:Country>
+        </cac:PostalAddress>
+        <cac:PartyTaxScheme>
+          <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:PartyTaxScheme>
+      </cac:TaxRepresentativeParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-NL/NL-R-007.xml
+++ b/rules/unit-UBL-NL/NL-R-007.xml
@@ -1,0 +1,562 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, the supplier MUST provide a means of payment (cac:PaymentMeans) if the payment is from customer to supplier</description>
+    <scope>NL-R-007</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-007</success>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-007</error>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-NL/NL-R-008.xml
+++ b/rules/unit-UBL-NL/NL-R-008.xml
@@ -1,0 +1,571 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, the payment means code (cac:PaymentMeans/cbc:PaymentMeansCode) MUST be one of 30, 48, 49, 57, 58 or 59</description>
+    <scope>NL-R-008</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-008</success>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-008</error>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>1</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-NL/NL-R-009.xml
+++ b/rules/unit-UBL-NL/NL-R-009.xml
@@ -1,0 +1,562 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+      <description>For suppliers in the Netherlands, if an order line reference (cac:OrderLineReference/cbc:LineID) is used, there must be an order reference on the document level (cac:OrderReference/cbc:ID)</description>
+    <scope>NL-R-009</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>NL-R-009</success>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>Customer reference for routing</cbc:BuyerReference>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:OrderLineReference>
+          <cbc:LineID>1</cbc:LineID>
+        </cac:OrderLineReference>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>NL-R-009</error>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>Customer reference for routing</cbc:BuyerReference>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:OrderLineReference>
+          <cbc:LineID>1</cbc:LineID>
+        </cac:OrderLineReference>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
+</testSet>


### PR DESCRIPTION
These rules are based on (part of) the NLCIUS. For the link between NLCIUS and these country-specific rules in Peppol BIS 3, see the document at
https://github.com/peppolautoriteit-nl/publications/blob/master/PeppolBIS_NL_RULES/PeppolBIS_NL_rules.md

The test files contain full documents for a success case and failure case for each rule, as I could not find any documentation on how the partial documents are applied to which base document (or any documentation on how to use or validate the test files, for that matter).

I did not include it in this PR, but I have some suggestions for a small reorganization that would make the code (and particularly, the country-specific rules) more maintainable, as currently they are quite inconsistent (in order, layout, and even marker comments). I might make a separate PR for that soonish.