### PR TITLE
Add cardinality of "0..1" for TaxCategory in AllowanceCharge

### DIFF
--- a/structure/syntax/part/allowance-charge.xml
+++ b/structure/syntax/part/allowance-charge.xml
@@ -126,7 +126,7 @@
             <Value type="EXAMPLE">1000</Value>
             
         </Element>
-    <Element>
+    <Element cardinality="0..1">
         <Term>cac:TaxCategory</Term>
         <Name>TAX CATEGORY</Name>
         


### PR DESCRIPTION
## Missing cardinality value for `TaxCategory` in `AllowanceCharge`
I'm creating a parser for the UBL invoice and credit note using the XML structure files `structure/syntax/ubl-invoice.xml` and `structure/syntax/ubl-creditnote.xml`, together with additional structure files found in `structure/syntax/part/`

My parser is finished and should in theory work for all valid input files. However, I have noticed that it fails to parse the `AllowanceCharge` element in some selected cases. The specific problem is that my parser utilizes the provided `cardinality` attribute found in some elements.

From my understanding, the following are valid cardinalities:
- Not specified: Required element
- “0..1”: Optional singular element
- “0..n”: Optional element (Can be more than one occurrence)
- “1..n”: Required elements (Is at least one)

The cardinality of the `TaxCategory` found in [structure/syntax/part/allowance-charge.xml](https://github.com/OpenPEPPOL/peppol-bis-invoice-3/blob/71c6c109874fcc881a027a9fc0a0bc3d188aa2ca/structure/syntax/part/allowance-charge.xml#L129). is not specified, which means, from my understanding, that it is a required element in any potential `AllowanceCharge` elements.

From my understanding, if an element with cardinality “0..n” exists, all sub-elements that do not have a cardinality specified (as TaxCategory) must be present for the element to be valid. I have tested with multiple files from a production database, and I have seen multiple cases where the `TaxCategory` element is not present when an allowance-charge element exists. I have attached some screenshots (with all sensitive data blacked out) where one can see that the TaxCategory is not present.

The input files on my part may of course be wrong, but I thought it was very unusual to have 30 out of 100 random samples I tested fail on only this part specifically.

The provided pull request adds the `0..1` optional singular element cardinality to the `TaxCategory` element. I have tested this patch locally and this fixes errors that the parser had.

### Screenshots
![image](https://user-images.githubusercontent.com/17567687/187966100-d023a60f-ed67-4220-83c9-176b50000203.png)
Here, the `AllowanceCharge` element is present, but missing the `TaxCategory` element

![image](https://user-images.githubusercontent.com/17567687/187966373-9d9d8f70-352a-45a3-82f0-b31628871a57.png)
The `TaxCategory` element is present with valid fields