### PR TITLE
Nl r 007 creditnote fix

### DIFF
--- a/rules/sch/PEPPOL-EN16931-CII.sch
+++ b/rules/sch/PEPPOL-EN16931-CII.sch
@@ -482,7 +482,7 @@ Last update: 2022 May release 3.0.13.
 
     <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementHeaderMonetarySummation[$supplierCountryIsNL]">
       <!-- Original rule in NLCIUS: BR-NL-11 -->
-      <assert id="NL-R-007" test="xs:decimal(ram:DuePayableAmount) &lt;= 0.0 or (/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans)" flag="fatal">[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (ram:SpecifiedTradeSettlementPaymentMeans) if the payment is from customer to supplier</assert>
+      <assert id="NL-R-007" test="xs:decimal(ram:DuePayableAmount) &lt;= 0.0 or (normalize-space(/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:TypeCode/text()) = '381') or (/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans)" flag="fatal">[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (ram:SpecifiedTradeSettlementPaymentMeans) if the payment is from customer to supplier</assert>
     </rule>
 
     <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans[$supplierCountryIsNL]">

--- a/rules/sch/PEPPOL-EN16931-CII.sch
+++ b/rules/sch/PEPPOL-EN16931-CII.sch
@@ -482,7 +482,11 @@ Last update: 2022 May release 3.0.13.
 
     <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementHeaderMonetarySummation[$supplierCountryIsNL]">
       <!-- Original rule in NLCIUS: BR-NL-11 -->
-      <assert id="NL-R-007" test="xs:decimal(ram:DuePayableAmount) &lt;= 0.0 or (normalize-space(/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:TypeCode/text()) = '381') or (/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans)" flag="fatal">[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (ram:SpecifiedTradeSettlementPaymentMeans) if the payment is from customer to supplier</assert>
+      <assert id="NL-R-007" test="(normalize-space(/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:TypeCode/text()) != '381' and
+                                   xs:decimal(ram:DuePayableAmount) &lt;= 0.0) or
+                                  (normalize-space(/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:TypeCode/text()) = '381' and
+                                   xs:decimal(ram:DuePayableAmount) &gt;= 0.0) or
+                                  (/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans)" flag="fatal">[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (ram:SpecifiedTradeSettlementPaymentMeans) if the payment is from customer to supplier</assert>
     </rule>
 
     <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans[$supplierCountryIsNL]">

--- a/rules/sch/PEPPOL-EN16931-UBL.sch
+++ b/rules/sch/PEPPOL-EN16931-UBL.sch
@@ -635,7 +635,7 @@ Last update: 2023 May release 3.0.15.
       <!-- Original rule in NLCIUS: BR-NL-5 -->
       <assert id="NL-R-006" test="cbc:StreetName and cbc:CityName and cbc:PostalZone" flag="fatal">[NL-R-006] For suppliers in the Netherlands, if the fiscal representative is in the Netherlands, the representative's address (cac:TaxRepresentativeParty/cac:PostalAddress) MUST contain street name (cbc:StreetName), city (cbc:CityName) and post code (cbc:PostalZone)</assert>
     </rule>
-    <rule context="cac:LegalMonetaryTotal[$supplierCountryIsNL]">
+    <rule context="ubl-invoice:Invoice/cac:LegalMonetaryTotal[$supplierCountryIsNL]">
       <!-- Original rule in NLCIUS: BR-NL-11 -->
       <assert id="NL-R-007" test="xs:decimal(cbc:PayableAmount) &lt;= 0.0 or (//cac:PaymentMeans)" flag="fatal">[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (cac:PaymentMeans) if the payment is from customer to supplier</assert>
     </rule>

--- a/rules/sch/PEPPOL-EN16931-UBL.sch
+++ b/rules/sch/PEPPOL-EN16931-UBL.sch
@@ -635,9 +635,9 @@ Last update: 2023 May release 3.0.15.
       <!-- Original rule in NLCIUS: BR-NL-5 -->
       <assert id="NL-R-006" test="cbc:StreetName and cbc:CityName and cbc:PostalZone" flag="fatal">[NL-R-006] For suppliers in the Netherlands, if the fiscal representative is in the Netherlands, the representative's address (cac:TaxRepresentativeParty/cac:PostalAddress) MUST contain street name (cbc:StreetName), city (cbc:CityName) and post code (cbc:PostalZone)</assert>
     </rule>
-    <rule context="ubl-invoice:Invoice/cac:LegalMonetaryTotal[$supplierCountryIsNL]">
+    <rule context="cac:LegalMonetaryTotal[$supplierCountryIsNL]">
       <!-- Original rule in NLCIUS: BR-NL-11 -->
-      <assert id="NL-R-007" test="xs:decimal(cbc:PayableAmount) &lt;= 0.0 or (//cac:PaymentMeans)" flag="fatal">[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (cac:PaymentMeans) if the payment is from customer to supplier</assert>
+      <assert id="NL-R-007" test="(/ubl-invoice:Invoice and xs:decimal(cbc:PayableAmount) &lt;= 0.0) or (/ubl-creditnote:CreditNote and xs:decimal(cbc:PayableAmount) &gt;= 0.0) or (//cac:PaymentMeans)" flag="fatal">[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (cac:PaymentMeans) if the payment is from customer to supplier</assert>
     </rule>
     <rule context="cac:PaymentMeans[$supplierCountryIsNL]">
       <!-- Original rule in NLCIUS: BR-NL-12 -->

--- a/rules/unit-CII-NL/NL-R-007.xml
+++ b/rules/unit-CII-NL/NL-R-007.xml
@@ -555,4 +555,206 @@
       </rsm:SupplyChainTradeTransaction>
     </rsm:CrossIndustryInvoice>
   </test>
+  <test>
+    <!-- Negative Credit Note document *should* have payment means -->
+    <assert>
+      <error>NL-R-007</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+      <rsm:ExchangedDocument>
+        <ram:ID>2018210</ram:ID>
+        <ram:TypeCode>381</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20180208</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Printing paper</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>1</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">-1000</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>25</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>-1000</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Parker Pen</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>5</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">-100</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>25</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>-500</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>3</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Eraser P-97</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>5</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">-500</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>12</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>-2500</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>Ref 123</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Allsälj AB</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">12345678</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet 1</ram:LineOne>
+              <ram:CityName>Commercity</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0190">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VAT">SE123456789001</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="FC">Godkänd för F-skatt</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyercompany ltd</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:CountryID>DK</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery />
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>-375</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>-1500</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>25</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>-300</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>-2500</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>12</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>0</ram:BasisAmount>
+            <ram:ActualAmount>0</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Loyal customer</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>25</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>0</ram:BasisAmount>
+            <ram:ActualAmount>0</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>25</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>-4000</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>0</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>0</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>-4000</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">-675</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>-4675</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>-4675</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+          <ram:InvoiceReferencedDocument>
+            <ram:IssuerAssignedID>12345</ram:IssuerAssignedID>
+          </ram:InvoiceReferencedDocument>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
 </testSet>

--- a/rules/unit-CII-NL/NL-R-007.xml
+++ b/rules/unit-CII-NL/NL-R-007.xml
@@ -1,21 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
   <assert>
-      <description>For suppliers in the Netherlands, the supplier MUST provide a means of payment (ram:SpecifiedTradeSettlementPaymentMeans) if the payment is from customer to supplier</description>
+    <description>For suppliers in the Netherlands, the supplier MUST provide a means of payment (ram:SpecifiedTradeSettlementPaymentMeans) if the payment is from customer to supplier</description>
     <scope>NL-R-007</scope>
   </assert>
   <test>
+    <!-- Standard test case that is correct -->
     <assert>
       <success>NL-R-007</success>
     </assert>
-    <rsm:CrossIndustryInvoice
-     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
-     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
-     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
-     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
-     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
-
+    <rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
       <rsm:ExchangedDocumentContext>
         <ram:BusinessProcessSpecifiedDocumentContextParameter>
           <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
@@ -24,7 +18,6 @@
           <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
         </ram:GuidelineSpecifiedDocumentContextParameter>
       </rsm:ExchangedDocumentContext>
-
       <rsm:ExchangedDocument>
         <ram:ID>12345</ram:ID>
         <ram:TypeCode>380</ram:TypeCode>
@@ -32,9 +25,7 @@
           <udt:DateTimeString format="102">20210101</udt:DateTimeString>
         </ram:IssueDateTime>
       </rsm:ExchangedDocument>
-
       <rsm:SupplyChainTradeTransaction>
-
         <ram:IncludedSupplyChainTradeLineItem>
           <ram:AssociatedDocumentLineDocument>
             <ram:LineID>1</ram:LineID>
@@ -61,7 +52,6 @@
             </ram:SpecifiedTradeSettlementLineMonetarySummation>
           </ram:SpecifiedLineTradeSettlement>
         </ram:IncludedSupplyChainTradeLineItem>
-
         <ram:IncludedSupplyChainTradeLineItem>
           <ram:AssociatedDocumentLineDocument>
             <ram:LineID>2</ram:LineID>
@@ -88,7 +78,6 @@
             </ram:SpecifiedTradeSettlementLineMonetarySummation>
           </ram:SpecifiedLineTradeSettlement>
         </ram:IncludedSupplyChainTradeLineItem>
-
         <ram:ApplicableHeaderTradeAgreement>
           <ram:BuyerReference>123_reference</ram:BuyerReference>
           <ram:SellerTradeParty>
@@ -109,7 +98,6 @@
               <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
             </ram:SpecifiedTaxRegistration>
           </ram:SellerTradeParty>
-
           <ram:BuyerTradeParty>
             <ram:Name>Buyers B.V.</ram:Name>
             <ram:PostalTradeAddress>
@@ -123,17 +111,14 @@
             </ram:URIUniversalCommunication>
           </ram:BuyerTradeParty>
         </ram:ApplicableHeaderTradeAgreement>
-
         <ram:ApplicableHeaderTradeDelivery>
           <ram:ShipToTradeParty>
             <ram:Name>Trade Party</ram:Name>
           </ram:ShipToTradeParty>
         </ram:ApplicableHeaderTradeDelivery>
-
         <ram:ApplicableHeaderTradeSettlement>
           <ram:PaymentReference>08/00355</ram:PaymentReference>
           <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
-
           <ram:SpecifiedTradeSettlementPaymentMeans>
             <ram:TypeCode>30</ram:TypeCode>
             <ram:PayeePartyCreditorFinancialAccount>
@@ -143,7 +128,6 @@
               <ram:BICID>BANKSBIC</ram:BICID>
             </ram:PayeeSpecifiedCreditorFinancialInstitution>
           </ram:SpecifiedTradeSettlementPaymentMeans>
-
           <ram:ApplicableTradeTax>
             <ram:CalculatedAmount>63</ram:CalculatedAmount>
             <ram:TypeCode>VAT</ram:TypeCode>
@@ -151,7 +135,6 @@
             <ram:CategoryCode>S</ram:CategoryCode>
             <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
           </ram:ApplicableTradeTax>
-
           <ram:SpecifiedTradeAllowanceCharge>
             <ram:ChargeIndicator>
               <udt:Indicator>false</udt:Indicator>
@@ -182,7 +165,6 @@
               <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
             </ram:CategoryTradeTax>
           </ram:SpecifiedTradeAllowanceCharge>
-
           <ram:SpecifiedTradePaymentTerms>
             <ram:DueDateDateTime>
               <udt:DateTimeString format="102">20180307</udt:DateTimeString>
@@ -199,21 +181,14 @@
           </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
         </ram:ApplicableHeaderTradeSettlement>
       </rsm:SupplyChainTradeTransaction>
-
     </rsm:CrossIndustryInvoice>
   </test>
   <test>
+    <!-- Standard test case that shows the error -->
     <assert>
       <error>NL-R-007</error>
     </assert>
-    <rsm:CrossIndustryInvoice
-     xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
-     xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
-     xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
-     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
-     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
-
+    <rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
       <rsm:ExchangedDocumentContext>
         <ram:BusinessProcessSpecifiedDocumentContextParameter>
           <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
@@ -222,7 +197,6 @@
           <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
         </ram:GuidelineSpecifiedDocumentContextParameter>
       </rsm:ExchangedDocumentContext>
-
       <rsm:ExchangedDocument>
         <ram:ID>12345</ram:ID>
         <ram:TypeCode>380</ram:TypeCode>
@@ -230,9 +204,7 @@
           <udt:DateTimeString format="102">20210101</udt:DateTimeString>
         </ram:IssueDateTime>
       </rsm:ExchangedDocument>
-
       <rsm:SupplyChainTradeTransaction>
-
         <ram:IncludedSupplyChainTradeLineItem>
           <ram:AssociatedDocumentLineDocument>
             <ram:LineID>1</ram:LineID>
@@ -259,7 +231,6 @@
             </ram:SpecifiedTradeSettlementLineMonetarySummation>
           </ram:SpecifiedLineTradeSettlement>
         </ram:IncludedSupplyChainTradeLineItem>
-
         <ram:IncludedSupplyChainTradeLineItem>
           <ram:AssociatedDocumentLineDocument>
             <ram:LineID>2</ram:LineID>
@@ -286,7 +257,6 @@
             </ram:SpecifiedTradeSettlementLineMonetarySummation>
           </ram:SpecifiedLineTradeSettlement>
         </ram:IncludedSupplyChainTradeLineItem>
-
         <ram:ApplicableHeaderTradeAgreement>
           <ram:BuyerReference>123_reference</ram:BuyerReference>
           <ram:SellerTradeParty>
@@ -307,7 +277,6 @@
               <ram:ID schemeID="VA">NL1111111111B01</ram:ID>
             </ram:SpecifiedTaxRegistration>
           </ram:SellerTradeParty>
-
           <ram:BuyerTradeParty>
             <ram:Name>Buyers B.V.</ram:Name>
             <ram:PostalTradeAddress>
@@ -321,17 +290,14 @@
             </ram:URIUniversalCommunication>
           </ram:BuyerTradeParty>
         </ram:ApplicableHeaderTradeAgreement>
-
         <ram:ApplicableHeaderTradeDelivery>
           <ram:ShipToTradeParty>
             <ram:Name>Trade Party</ram:Name>
           </ram:ShipToTradeParty>
         </ram:ApplicableHeaderTradeDelivery>
-
         <ram:ApplicableHeaderTradeSettlement>
           <ram:PaymentReference>08/00355</ram:PaymentReference>
           <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
-
           <ram:ApplicableTradeTax>
             <ram:CalculatedAmount>63</ram:CalculatedAmount>
             <ram:TypeCode>VAT</ram:TypeCode>
@@ -339,7 +305,6 @@
             <ram:CategoryCode>S</ram:CategoryCode>
             <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
           </ram:ApplicableTradeTax>
-
           <ram:SpecifiedTradeAllowanceCharge>
             <ram:ChargeIndicator>
               <udt:Indicator>false</udt:Indicator>
@@ -370,7 +335,6 @@
               <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
             </ram:CategoryTradeTax>
           </ram:SpecifiedTradeAllowanceCharge>
-
           <ram:SpecifiedTradePaymentTerms>
             <ram:DueDateDateTime>
               <udt:DateTimeString format="102">20180307</udt:DateTimeString>
@@ -387,7 +351,208 @@
           </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
         </ram:ApplicableHeaderTradeSettlement>
       </rsm:SupplyChainTradeTransaction>
-
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <!-- Testcase for CreditNote; without paymentmeans these should not fail validation -->
+    <assert>
+      <success>NL-R-007</success>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice_100pD16B.xsd">
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+      <rsm:ExchangedDocument>
+        <ram:ID>2018210</ram:ID>
+        <ram:TypeCode>381</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20180208</udt:DateTimeString>
+        </ram:IssueDateTime>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Printing paper</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>1</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">1000</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>25</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>1000</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>2</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Parker Pen</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>5</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">100</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>25</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>500</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>3</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Eraser P-97</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>5</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="EA">500</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>12</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>2500</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerReference>Ref 123</ram:BuyerReference>
+          <ram:SellerTradeParty>
+            <ram:Name>Allsälj AB</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">12345678</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>1234AA</ram:PostcodeCode>
+              <ram:LineOne>SellerStreet 1</ram:LineOne>
+              <ram:CityName>Commercity</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0190">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VAT">SE123456789001</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="FC">Godkänd för F-skatt</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+          <ram:BuyerTradeParty>
+            <ram:Name>Buyercompany ltd</ram:Name>
+            <ram:PostalTradeAddress>
+              <ram:CountryID>DK</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery />
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>08/00355</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>SEK</ram:InvoiceCurrencyCode>
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>375</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>1500</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>25</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>300</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>2500</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>12</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>0</ram:BasisAmount>
+            <ram:ActualAmount>0</ram:ActualAmount>
+            <ram:ReasonCode>95</ram:ReasonCode>
+            <ram:Reason>Loyal customer</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>25</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>true</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:CalculationPercent>10</ram:CalculationPercent>
+            <ram:BasisAmount>0</ram:BasisAmount>
+            <ram:ActualAmount>0</ram:ActualAmount>
+            <ram:ReasonCode>ABL</ram:ReasonCode>
+            <ram:Reason>Packaging</ram:Reason>
+            <ram:CategoryTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>25</ram:RateApplicablePercent>
+            </ram:CategoryTradeTax>
+          </ram:SpecifiedTradeAllowanceCharge>
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20180307</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>4000</ram:LineTotalAmount>
+            <ram:ChargeTotalAmount>0</ram:ChargeTotalAmount>
+            <ram:AllowanceTotalAmount>0</ram:AllowanceTotalAmount>
+            <ram:TaxBasisTotalAmount>4000</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="SEK">675</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>4675</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>4675</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+          <ram:InvoiceReferencedDocument>
+            <ram:IssuerAssignedID>12345</ram:IssuerAssignedID>
+          </ram:InvoiceReferencedDocument>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
     </rsm:CrossIndustryInvoice>
   </test>
 </testSet>

--- a/rules/unit-UBL-NL/NL-R-007.xml
+++ b/rules/unit-UBL-NL/NL-R-007.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
   <assert>
-      <description>For suppliers in the Netherlands, the supplier MUST provide a means of payment (cac:PaymentMeans) if the payment is from customer to supplier</description>
+    <description>For suppliers in the Netherlands, the supplier MUST provide a means of payment (cac:PaymentMeans) if the payment is from customer to supplier</description>
     <scope>NL-R-007</scope>
   </assert>
   <test>
+    <!-- Standard test case that is correct -->
     <assert>
       <success>NL-R-007</success>
     </assert>
@@ -181,7 +182,6 @@
           </cac:ClassifiedTaxCategory>
         </cac:Item>
         <cac:Price>
-          <!-- Nett price excluding VAT and BPM-->
           <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
         </cac:Price>
       </cac:InvoiceLine>
@@ -287,6 +287,7 @@
     </doc:Invoice>
   </test>
   <test>
+    <!-- Standard test case that shows the error -->
     <assert>
       <error>NL-R-007</error>
     </assert>
@@ -454,7 +455,6 @@
           </cac:ClassifiedTaxCategory>
         </cac:Item>
         <cac:Price>
-          <!-- Nett price excluding VAT and BPM-->
           <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
         </cac:Price>
       </cac:InvoiceLine>
@@ -558,5 +558,174 @@
         </cac:Price>
       </cac:InvoiceLine>
     </doc:Invoice>
+  </test>
+  <test>
+    <!-- Testcase for CreditNote; without paymentmeans these should not fail validation -->
+    <assert>
+      <success>NL-R-007</success>
+    </assert>
+    <CreditNote xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>12115118</cbc:ID>
+      <cbc:IssueDate>2015-01-09</cbc:IssueDate>
+      <cbc:CreditNoteTypeCode>381</cbc:CreditNoteTypeCode>
+      <cbc:Note>
+        Alle leveringen zijn franco. Alle prijzen zijn incl. BTW. Betalingstermijn: 14 dagen netto. Prijswijzigingen voorbehouden. Op al onze
+        aanbiedingen, leveringen en overeenkomsten zijn van toepassing in de algemene verkoop en leveringsvoorwaarden. Gedeponeerd bij de K.v.K. te
+        Amsterdam 25-04-'85##Delivery terms
+      </cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>47806</cbc:BuyerReference>
+      <cac:OrderReference>
+        <cbc:ID>47806</cbc:ID>
+      </cac:OrderReference>
+      <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+          <cbc:ID>46568</cbc:ID>
+        </cac:InvoiceDocumentReference>
+      </cac:BillingReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">SITEST00000</cbc:EndpointID>
+          <cac:PostalAddress>
+            <cbc:StreetName>Simplerstraat 1</cbc:StreetName>
+            <cbc:CityName>InvoicingStad</cbc:CityName>
+            <cbc:PostalZone>1111 ZZ</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL1111.11.111.B.01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>SimplerInvoicing</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">SITEST00000</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">11111111</cbc:EndpointID>
+          <cac:PartyIdentification>
+            <cbc:ID>10202</cbc:ID>
+          </cac:PartyIdentification>
+          <cac:PostalAddress>
+            <cbc:StreetName>Teststraat 123</cbc:StreetName>
+            <cbc:CityName>Grotestad</cbc:CityName>
+            <cbc:PostalZone>1111 AA</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Ontvanger</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">11111111</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentTerms>
+        <cbc:Note>Credit note</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">27.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">6.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>6</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">200.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">200.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">227.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">227.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:CreditNoteLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:CreditedQuantity unitCode="C62">4</cbc:CreditedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">200.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>SimplerInvoicing test invoice</cbc:Name>
+          <cac:SellersItemIdentification>
+            <cbc:ID>166022</cbc:ID>
+          </cac:SellersItemIdentification>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">50.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:CreditNoteLine>
+      <cac:CreditNoteLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:CreditedQuantity unitCode="C62">1</cbc:CreditedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Testing procedures</cbc:Name>
+          <cac:SellersItemIdentification>
+            <cbc:ID>661813</cbc:ID>
+          </cac:SellersItemIdentification>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>6</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:CreditNoteLine>
+      <cac:CreditNoteLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:CreditedQuantity unitCode="C62">-1</cbc:CreditedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">-100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Previous Test CreditNote returned</cbc:Name>
+          <cac:SellersItemIdentification>
+            <cbc:ID>438146</cbc:ID>
+          </cac:SellersItemIdentification>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:CreditNoteLine>
+    </CreditNote>
   </test>
 </testSet>

--- a/rules/unit-UBL-NL/NL-R-007.xml
+++ b/rules/unit-UBL-NL/NL-R-007.xml
@@ -728,4 +728,173 @@
       </cac:CreditNoteLine>
     </CreditNote>
   </test>
+  <test>
+    <!-- Negative Credit Note document *should* have payment means -->
+    <assert>
+      <error>NL-R-007</error>
+    </assert>
+    <CreditNote xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>12115118</cbc:ID>
+      <cbc:IssueDate>2015-01-09</cbc:IssueDate>
+      <cbc:CreditNoteTypeCode>381</cbc:CreditNoteTypeCode>
+      <cbc:Note>
+        Alle leveringen zijn franco. Alle prijzen zijn incl. BTW. Betalingstermijn: 14 dagen netto. Prijswijzigingen voorbehouden. Op al onze
+        aanbiedingen, leveringen en overeenkomsten zijn van toepassing in de algemene verkoop en leveringsvoorwaarden. Gedeponeerd bij de K.v.K. te
+        Amsterdam 25-04-'85##Delivery terms
+      </cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>47806</cbc:BuyerReference>
+      <cac:OrderReference>
+        <cbc:ID>47806</cbc:ID>
+      </cac:OrderReference>
+      <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+          <cbc:ID>46568</cbc:ID>
+        </cac:InvoiceDocumentReference>
+      </cac:BillingReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">SITEST00000</cbc:EndpointID>
+          <cac:PostalAddress>
+            <cbc:StreetName>Simplerstraat 1</cbc:StreetName>
+            <cbc:CityName>InvoicingStad</cbc:CityName>
+            <cbc:PostalZone>1111 ZZ</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL1111.11.111.B.01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>SimplerInvoicing</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">SITEST00000</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">11111111</cbc:EndpointID>
+          <cac:PartyIdentification>
+            <cbc:ID>10202</cbc:ID>
+          </cac:PartyIdentification>
+          <cac:PostalAddress>
+            <cbc:StreetName>Teststraat 123</cbc:StreetName>
+            <cbc:CityName>Grotestad</cbc:CityName>
+            <cbc:PostalZone>1111 AA</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Ontvanger</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">11111111</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentTerms>
+        <cbc:Note>Credit note</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">-27.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">-100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">-21.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">-100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">-6.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>6</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">-200.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">-200.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">-227.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">-227.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:CreditNoteLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:CreditedQuantity unitCode="C62">-4</cbc:CreditedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">-200.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>SimplerInvoicing test invoice</cbc:Name>
+          <cac:SellersItemIdentification>
+            <cbc:ID>166022</cbc:ID>
+          </cac:SellersItemIdentification>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">50.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:CreditNoteLine>
+      <cac:CreditNoteLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:CreditedQuantity unitCode="C62">-1</cbc:CreditedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">-100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Testing procedures</cbc:Name>
+          <cac:SellersItemIdentification>
+            <cbc:ID>661813</cbc:ID>
+          </cac:SellersItemIdentification>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>6</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:CreditNoteLine>
+      <cac:CreditNoteLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:CreditedQuantity unitCode="C62">1</cbc:CreditedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Previous Test CreditNote returned</cbc:Name>
+          <cac:SellersItemIdentification>
+            <cbc:ID>438146</cbc:ID>
+          </cac:SellersItemIdentification>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:CreditNoteLine>
+    </CreditNote>
+  </test>
 </testSet>


### PR DESCRIPTION
This is a PR for a fix in country-specific rule NL-R-007; this rule checks that a PaymentMeans is present if the payable amount is positive.

The original rule also fired on CreditNote documents, which should not happen.

In case of UBL, this is a change in the context (Invoice only); in case of CII, the assertion also succeeds if the typecode is 381.

Added a testcase for creditnotes to the unit tests as well, but I don't think I have a way to verify the unit tests themselves.