### PR TITLE
Make country-specific rule NL-R-008 domestic (NL->NL) only

### DIFF
--- a/rules/sch/PEPPOL-EN16931-CII.sch
+++ b/rules/sch/PEPPOL-EN16931-CII.sch
@@ -485,14 +485,14 @@ Last update: 2022 May release 3.0.13.
       <assert id="NL-R-007" test="xs:decimal(ram:DuePayableAmount) &lt;= 0.0 or (/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans)" flag="fatal">[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (ram:SpecifiedTradeSettlementPaymentMeans) if the payment is from customer to supplier</assert>
     </rule>
 
-    <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans[$supplierCountryIsNL]">
+    <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans[$supplierCountryIsNL and $customerCountryIsNL]">
       <!-- Original rule in NLCIUS: BR-NL-12 -->
       <assert id="NL-R-008" test="normalize-space(ram:TypeCode) = '30' or
                 normalize-space(ram:TypeCode) = '48' or
                 normalize-space(ram:TypeCode) = '49' or
                 normalize-space(ram:TypeCode) = '57' or
                 normalize-space(ram:TypeCode) = '58' or
-                normalize-space(ram:TypeCode) = '59'" flag="fatal">[NL-R-008] For suppliers in the Netherlands, the payment means code (ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode) MUST be one of 30, 48, 49, 57, 58 or 59</assert>
+                normalize-space(ram:TypeCode) = '59'" flag="fatal">[NL-R-008] For suppliers in the Netherlands, if the customer is in the Netherlands, the payment means code (ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode) MUST be one of 30, 48, 49, 57, 58 or 59</assert>
     </rule>
 
     <rule context="rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:LineID[$supplierCountryIsNL]">

--- a/rules/sch/PEPPOL-EN16931-UBL.sch
+++ b/rules/sch/PEPPOL-EN16931-UBL.sch
@@ -640,14 +640,14 @@ Last update: 2023 May release 3.0.15.
       <!-- Original rule in NLCIUS: BR-NL-11 -->
       <assert id="NL-R-007" test="xs:decimal(cbc:PayableAmount) &lt;= 0.0 or (//cac:PaymentMeans)" flag="fatal">[NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment (cac:PaymentMeans) if the payment is from customer to supplier</assert>
     </rule>
-    <rule context="cac:PaymentMeans[$supplierCountryIsNL]">
+    <rule context="cac:PaymentMeans[$supplierCountryIsNL and $customerCountryIsNL]">
       <!-- Original rule in NLCIUS: BR-NL-12 -->
       <assert id="NL-R-008" test="normalize-space(cbc:PaymentMeansCode) = '30' or
         normalize-space(cbc:PaymentMeansCode) = '48' or
         normalize-space(cbc:PaymentMeansCode) = '49' or
         normalize-space(cbc:PaymentMeansCode) = '57' or
         normalize-space(cbc:PaymentMeansCode) = '58' or
-        normalize-space(cbc:PaymentMeansCode) = '59'" flag="fatal">[NL-R-008] For suppliers in the Netherlands, the payment means code (cac:PaymentMeans/cbc:PaymentMeansCode) MUST be one of 30, 48, 49, 57, 58 or 59</assert>
+        normalize-space(cbc:PaymentMeansCode) = '59'" flag="fatal">[NL-R-008] For suppliers in the Netherlands, if the customer is in the Netherlands, the payment means code (cac:PaymentMeans/cbc:PaymentMeansCode) MUST be one of 30, 48, 49, 57, 58 or 59</assert>
     </rule>
     <rule context="cac:OrderLineReference/cbc:LineID[$supplierCountryIsNL]">
       <!-- Original rule in NLCIUS: BR-NL-13 -->

--- a/rules/unit-CII-NL/NL-R-008.xml
+++ b/rules/unit-CII-NL/NL-R-008.xml
@@ -401,4 +401,177 @@
 
     </rsm:CrossIndustryInvoice>
   </test>
+  <test>
+      <!-- Rule should only trigger for domestic use -->
+      <assert>
+          <success>NL-R-008</success>
+      </assert>
+    <?xml version="1.0" encoding="utf-8"?>
+    <!-- XML instance generated STPE (STPE.nl), based on an example by Andreas Pelekies -->
+    <!-- Based on 'Example 8: Electricity for EN16931' published by CEN on https://github.com/ConnectingEurope -->
+    <rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+      <rsm:ExchangedDocumentContext>
+        <ram:BusinessProcessSpecifiedDocumentContextParameter>
+          <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+        </ram:BusinessProcessSpecifiedDocumentContextParameter>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+          <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+      </rsm:ExchangedDocumentContext>
+      <rsm:ExchangedDocument>
+        <ram:ID>1100512149</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+          <udt:DateTimeString format="102">20141110</udt:DateTimeString>
+        </ram:IssueDateTime>
+        <ram:IncludedNote>
+          <ram:Content>
+            Periodieke afrekening
+            U vindt een toelichting op uw factuur via www.energieleverancier.nl/factuur_grootzakelijk
+            Op alle diensten en overeenkomsten zijn de algemene voorwaarden aansluiting en
+            transport grootverbruik elektriciteit, respectievelijk gas van toepassing
+            www.energieleverancier.nl
+          </ram:Content>
+        </ram:IncludedNote>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+          <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>1</ram:LineID>
+          </ram:AssociatedDocumentLineDocument>
+          <ram:SpecifiedTradeProduct>
+            <ram:Name>Getransporteerde kWh’s</ram:Name>
+          </ram:SpecifiedTradeProduct>
+          <ram:SpecifiedLineTradeAgreement>
+            <ram:BuyerOrderReferencedDocument>
+              <ram:LineID>1</ram:LineID>
+            </ram:BuyerOrderReferencedDocument>
+            <ram:NetPriceProductTradePrice>
+              <ram:ChargeAmount>100.00</ram:ChargeAmount>
+              <ram:BasisQuantity unitCode="KWH">1.00</ram:BasisQuantity>
+            </ram:NetPriceProductTradePrice>
+          </ram:SpecifiedLineTradeAgreement>
+          <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="KWH">1</ram:BilledQuantity>
+          </ram:SpecifiedLineTradeDelivery>
+          <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+              <ram:TypeCode>VAT</ram:TypeCode>
+              <ram:CategoryCode>S</ram:CategoryCode>
+              <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+              <ram:LineTotalAmount>100.00</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+          </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:Name>Energieleverancier B.V.</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">17131139</ram:ID>
+              <ram:TradingBusinessName>Energieleverancier</ram:TradingBusinessName>
+            </ram:SpecifiedLegalOrganization>
+            <ram:DefinedTradeContact>
+              <ram:EmailURIUniversalCommunication>
+                <ram:URIID>klantenservice.zakelijk@energieleverancier.nl</ram:URIID>
+              </ram:EmailURIUniversalCommunication>
+            </ram:DefinedTradeContact>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>5223MB</ram:PostcodeCode>
+              <ram:LineOne>Magistratenlaan 116</ram:LineOne>
+              <ram:CityName>'S-HERTOGENBOSCH</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+            <ram:SpecifiedTaxRegistration>
+              <ram:ID schemeID="VA">NL809561074B01</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+          </ram:SellerTradeParty>
+          <ram:BuyerTradeParty>
+            <ram:ID>1081119</ram:ID>
+            <ram:Name>Klant</ram:Name>
+            <ram:SpecifiedLegalOrganization>
+              <ram:ID schemeID="0106">13524678</ram:ID>
+            </ram:SpecifiedLegalOrganization>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>9999 XX</ram:PostcodeCode>
+              <ram:LineOne>Bedrijfslaan 4</ram:LineOne>
+              <ram:CityName>ONDERNEMERSTØD</ram:CityName>
+              <ram:CountryID>SE</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+          <ram:BuyerOrderReferencedDocument>
+            <ram:IssuerAssignedID>PO4711</ram:IssuerAssignedID>
+          </ram:BuyerOrderReferencedDocument>
+          <ram:AdditionalReferencedDocument>
+            <ram:IssuerAssignedID>871694831000290806</ram:IssuerAssignedID>
+            <ram:TypeCode>130</ram:TypeCode>
+          </ram:AdditionalReferencedDocument>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery>
+          <ram:ShipToTradeParty>
+            <ram:PostalTradeAddress>
+              <ram:PostcodeCode>9999 XX</ram:PostcodeCode>
+              <ram:LineOne>Bedrijfslaan 4,</ram:LineOne>
+              <ram:CityName>ONDERNEMERSTAD</ram:CityName>
+              <ram:CountryID>NL</ram:CountryID>
+            </ram:PostalTradeAddress>
+          </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+        <ram:ApplicableHeaderTradeSettlement>
+          <ram:PaymentReference>1100512149</ram:PaymentReference>
+          <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>54</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:IBANID>NL28RBOS0420242228</ram:IBANID>
+            </ram:PayeePartyCreditorFinancialAccount>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+              <ram:IBANID>NL28RBOS0420242228</ram:IBANID>
+            </ram:PayeePartyCreditorFinancialAccount>
+          </ram:SpecifiedTradeSettlementPaymentMeans>
+          <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>21.00</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>100.00</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>21</ram:RateApplicablePercent>
+          </ram:ApplicableTradeTax>
+          <ram:BillingSpecifiedPeriod>
+            <ram:StartDateTime>
+              <udt:DateTimeString format="102">20140801</udt:DateTimeString>
+            </ram:StartDateTime>
+            <ram:EndDateTime>
+              <udt:DateTimeString format="102">20140831</udt:DateTimeString>
+            </ram:EndDateTime>
+          </ram:BillingSpecifiedPeriod>
+          <ram:SpecifiedTradePaymentTerms>
+            <ram:Description>
+              Energieleverancier brengt wettelijke rente in rekening over te laat betaalde
+              facturen. Kijk voor informatie op www.energieleverancier.nl/rentenota
+            </ram:Description>
+            <ram:DueDateDateTime>
+              <udt:DateTimeString format="102">20141124</udt:DateTimeString>
+            </ram:DueDateDateTime>
+          </ram:SpecifiedTradePaymentTerms>
+          <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>100.00</ram:LineTotalAmount>
+            <ram:TaxBasisTotalAmount>100.00</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="EUR">21.00</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>121.00</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>121.00</ram:DuePayableAmount>
+          </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
 </testSet>

--- a/rules/unit-UBL-NL/NL-R-008.xml
+++ b/rules/unit-UBL-NL/NL-R-008.xml
@@ -568,4 +568,286 @@
       </cac:InvoiceLine>
     </doc:Invoice>
   </test>
+  <test>
+    <assert>
+      <success>NL-R-008</success>
+    </assert>
+    <doc:Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:doc="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>10000005</cbc:ID>
+      <cbc:IssueDate>2021-02-23</cbc:IssueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:Note>KIA STONIC PE 1.0 TGDI 100pk MHEV DynamicPlusLine</cbc:Note>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cac:InvoicePeriod>
+        <cbc:StartDate>2021-02-23</cbc:StartDate>
+        <cbc:EndDate>2021-02-23</cbc:EndDate>
+      </cac:InvoicePeriod>
+      <cac:OrderReference>
+        <cbc:ID>Customer PO number</cbc:ID>
+      </cac:OrderReference>
+      <cac:AdditionalDocumentReference>
+        <cbc:ID>attachment.PDF</cbc:ID>
+        <cac:Attachment>
+          <cbc:EmbeddedDocumentBinaryObject filename="attachment.PDF" mimeCode="application/pdf">BASE64CODEINHERE</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+      </cac:AdditionalDocumentReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Leaseme NL B.V.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Emma van Laarsomweg 3</cbc:StreetName>
+            <cbc:CityName>Rotterdam</cbc:CityName>
+            <cbc:PostalZone>3050 DG</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL123456789B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Leaseme NL B.V.</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Supplier contact name</cbc:Name>
+            <cbc:Telephone>051-1111111</cbc:Telephone>
+            <cbc:ElectronicMail>supplier@leaseme.com</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">87654321</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Customer name</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Street 2</cbc:StreetName>
+            <cbc:CityName>City</cbc:CityName>
+            <cbc:PostalZone>1234 AB</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>NL987654321B01</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Customer name as registered in KvK</cbc:RegistrationName>
+            <cbc:CompanyID schemeID="0106">87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2021-02-24</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>1</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>NL63RABO00000000123</cbc:ID>
+          <cac:FinancialInstitutionBranch>
+            <cbc:ID>INGBNL2A</cbc:ID>
+          </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment according to agreed payment terms</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Kosten afgifte kenteken deel 1A</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">53.40</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>BPM</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="EUR">3410.00</cbc:Amount>
+        <cac:TaxCategory>
+          <cbc:ID>Z</cbc:ID>
+          <cbc:Percent>0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:AllowanceCharge>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">17119.80</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">3595.17</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">3463.40</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>Z</cbc:ID>
+            <cbc:Percent>0.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">17119.80</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">20583.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">24178.37</cbc:TaxInclusiveAmount>
+        <cbc:ChargeTotalAmount currencyID="EUR">3463.40</cbc:ChargeTotalAmount>
+        <cbc:PayableRoundingAmount currencyID="EUR">0.00</cbc:PayableRoundingAmount>
+        <cbc:PayableAmount currencyID="EUR">24178.37</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">15929.32</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Korting 8,5%</cbc:AllowanceChargeReason>
+          <cbc:MultiplierFactorNumeric>8.5</cbc:MultiplierFactorNumeric>
+          <cbc:Amount currencyID="EUR">1479.77</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">17409.09</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Verkoopprijs personenwagen exclusief bpm en btw</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <!-- Nett price excluding VAT and BPM-->
+          <cbc:PriceAmount currencyID="EUR">17409.09</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">449.94</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:AllowanceChargeReason>Totaal korting opties en accessoires</cbc:AllowanceChargeReason>
+          <cbc:Amount currencyID="EUR">41.80</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+          <cbc:Name>Opties en accessoires</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+          <cac:AdditionalItemProperty>
+            <cbc:Name>Kleur</cbc:Name>
+            <cbc:Value>Perennial Grey</cbc:Value>
+          </cac:AdditionalItemProperty>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">491.74</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.50</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Kosten rijklaarmaken</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">600.50</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>4</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">45.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Mattenset, gevarendriehoek en lampenset</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">45.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>5</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">61.98</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Brandstof</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">61.98</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+      <cac:InvoiceLine>
+        <cbc:ID>6</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">33.06</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Recyclingbijdrage</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>21.00</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">33.06</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </doc:Invoice>
+  </test>
 </testSet>


### PR DESCRIPTION
Make country-specific rule NL-R-008 domestic-only

As suggested by https://github.com/peppolautoriteit-nl/validation/issues/41, and discussed within the NPa SP tech community, this rule should trigger only for domestic traffic.

Therefore, this change adds a check for the customer's country in the rule context, similar to other rules.

There are two commits, one for UBL and once for CII. Test cases have been added, but not run (I still don't know how to execute these tests).

Official PR will be submitted to the service desk shortly.