### PR TITLE
Added BT-150 reference to syntax mapping

### DIFF
--- a/structure/syntax/part/price.xml
+++ b/structure/syntax/part/price.xml
@@ -51,6 +51,8 @@
                 <Description>The unit of measure that applies to the Item price base quantity, must be the same as the unit code of the Invoiced/credited quantity. Codes for unit of packaging from UNECE Recommendation No. 21 can be used in accordance with the descriptions in the "Intro" section of UN/ECE Recommendation 20, Revision 11 (2015):
                     The 2 character alphanumeric code values in UNECE Recommendation 21 shall be used. To avoid duplication with existing code values in UNECE Recommendation No. 20, each code value from UNECE Recommendation 21 shall be prefixed with an “X”, resulting in a 3 alphanumeric code when used as a unit of measure.
                 </Description>
+                <DataType>Code</DataType>
+                <Reference type="BUSINESS_TERM">BT-150</Reference>
                 <Reference type="CODE_LIST">UNECERec20</Reference>
                 <Reference type="RULE">PEPPOL-EN16931-R130</Reference>
                 <Value type="EXAMPLE">C62</Value>


### PR DESCRIPTION
Added a reference to BT-150, plus the data type of the attribute to the definition of `cac:InvoiceLine/cac:Price/cbc:BaseQuantity/@unitCode`. Not sure if this is a sensible change or not as I'm (mis)using the raw xml files to implement a mapping from the UBL syntax to the semantic data model of the EN16931 standard by hand. I've no idea what the files in `structure/syntax` are actually used for.[^1]

Service-desk ticket: PEPPOL-14378

[^1]: I assume it is used to generate the docs at https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/tree/, but that's just guesswork.