### PR TITLE
Add format checks for identifiers with scheme 0106, 0190, 0217, 9944,…

### DIFF
--- a/rules/sch/PEPPOL-EN16931-CII.sch
+++ b/rules/sch/PEPPOL-EN16931-CII.sch
@@ -352,21 +352,21 @@ Last update: 2025 November release 3.0.20.
       <assert id="PEPPOL-COMMON-R050" test="u:abn(normalize-space())" flag="fatal">Australian Business Number (ABN) MUST be stated in the correct format.</assert>
     </rule>
 	<rule context="ram:URIID[@schemeID = '0106'] | ram:ID[@schemeID = '0106'] | ram:GlobalID[@schemeID = '0106']">
-      <assert id="PEPPOL-COMMON-R054" test="matches(normalize-space(), '^[0-9]{8}$')" flag="fatal">Dutch Chamber of Commerce (KVK) numbers (0106) MUST be stated in the correct format (12345678).</assert>
+      <assert id="PEPPOL-COMMON-R054" test="matches(normalize-space(), '^[0-9]{8}$')" flag="warning">Dutch Chamber of Commerce (KVK) numbers (0106) MUST be stated in the correct format (12345678).</assert>
     </rule>
 	<rule context="ram:URIID[@schemeID = '0190'] | ram:ID[@schemeID = '0190'] | ram:GlobalID[@schemeID = '0190']">
-      <assert id="PEPPOL-COMMON-R055" test="matches(normalize-space(), '^[0-9]{20}$')" flag="fatal">Dutch organization identification numbers (0190) MUST be stated in the correct format (12345678901234567890).</assert>
+      <assert id="PEPPOL-COMMON-R055" test="matches(normalize-space(), '^[0-9]{20}$')" flag="warning">Dutch organization identification numbers (0190) MUST be stated in the correct format (12345678901234567890).</assert>
     </rule>
 	<rule context="ram:URIID[@schemeID = '9944'] | ram:ID[@schemeID = '9944'] | ram:GlobalID[@schemeID = '9944']">
-      <assert id="PEPPOL-COMMON-R056-1" test="matches(normalize-space(), '^NL[0-9]{9}B[0-9]{2}$')" flag="fatal">Dutch VAT numbers (9944) MUST be stated in the correct format (NL123456789B12).</assert>
+      <assert id="PEPPOL-COMMON-R056-1" test="matches(normalize-space(), '^NL[0-9]{9}B[0-9]{2}$')" flag="warning">Dutch VAT numbers (9944) MUST be stated in the correct format (NL123456789B12).</assert>
     </rule>
     <rule context="ram:SpecifiedTaxRegistration[ram:ID/@schemeID = 'VA'][starts-with(normalize-space(.), 'NL')]">
       <assert id="PEPPOL-COMMON-R056-2"
         test="matches(normalize-space(.), '^NL[0-9]{9}B[0-9]{2}$')"
-        flag="fatal">Dutch VAT numbers MUST have the format (NL123456789B12).</assert>
+        flag="warning">Dutch VAT numbers MUST have the format (NL123456789B12).</assert>
     </rule>
 	<rule context="ram:URIID[@schemeID = '0217'] | ram:ID[@schemeID = '0217'] | ram:GlobalID[@schemeID = '0217']">
-      <assert id="PEPPOL-COMMON-R057" test="matches(normalize-space(), '^[0-9]{20}$')" flag="fatal">Dutch Chamber of Commerce Establishment numbers (0217) MUST be stated in the correct format (12345678901234567890).</assert>
+      <assert id="PEPPOL-COMMON-R057" test="matches(normalize-space(), '^[0-9]{20}$')" flag="warning">Dutch Chamber of Commerce Establishment numbers (0217) MUST be stated in the correct format (12345678901234567890).</assert>
     </rule>
 <!--
 -->

--- a/rules/sch/PEPPOL-EN16931-CII.sch
+++ b/rules/sch/PEPPOL-EN16931-CII.sch
@@ -351,7 +351,25 @@ Last update: 2025 November release 3.0.20.
 	<rule context="ram:URIID[@schemeID = '0151'] | ram:ID[@schemeID = '0151'] | ram:GlobalID[@schemeID = '0151']">
       <assert id="PEPPOL-COMMON-R050" test="u:abn(normalize-space())" flag="fatal">Australian Business Number (ABN) MUST be stated in the correct format.</assert>
     </rule>
-
+	<rule context="ram:URIID[@schemeID = '0106'] | ram:ID[@schemeID = '0106'] | ram:GlobalID[@schemeID = '0106']">
+      <assert id="PEPPOL-COMMON-R054" test="matches(normalize-space(), '^[0-9]{8}$')" flag="fatal">Dutch Chamber of Commerce (KVK) numbers (0106) MUST be stated in the correct format (12345678).</assert>
+    </rule>
+	<rule context="ram:URIID[@schemeID = '0190'] | ram:ID[@schemeID = '0190'] | ram:GlobalID[@schemeID = '0190']">
+      <assert id="PEPPOL-COMMON-R055" test="matches(normalize-space(), '^[0-9]{20}$')" flag="fatal">Dutch organization identification numbers (0190) MUST be stated in the correct format (12345678901234567890).</assert>
+    </rule>
+	<rule context="ram:URIID[@schemeID = '9944'] | ram:ID[@schemeID = '9944'] | ram:GlobalID[@schemeID = '9944']">
+      <assert id="PEPPOL-COMMON-R056-1" test="matches(normalize-space(), '^NL[0-9]{9}B[0-9]{2}$')" flag="fatal">Dutch VAT numbers (9944) MUST be stated in the correct format (NL123456789B12).</assert>
+    </rule>
+    <rule context="ram:SpecifiedTaxRegistration[ram:ID/@schemeID = 'VA'][starts-with(normalize-space(.), 'NL')]">
+      <assert id="PEPPOL-COMMON-R056-2"
+        test="matches(normalize-space(.), '^NL[0-9]{9}B[0-9]{2}$')"
+        flag="fatal">Dutch VAT numbers MUST have the format (NL123456789B12).</assert>
+    </rule>
+	<rule context="ram:URIID[@schemeID = '0217'] | ram:ID[@schemeID = '0217'] | ram:GlobalID[@schemeID = '0217']">
+      <assert id="PEPPOL-COMMON-R057" test="matches(normalize-space(), '^[0-9]{20}$')" flag="fatal">Dutch Chamber of Commerce Establishment numbers (0217) MUST be stated in the correct format (12345678901234567890).</assert>
+    </rule>
+<!--
+-->
   </pattern>
   <!-- National rules -->
   <pattern>

--- a/rules/sch/PEPPOL-EN16931-UBL.sch
+++ b/rules/sch/PEPPOL-EN16931-UBL.sch
@@ -498,6 +498,35 @@ Last update: 2025 November release 3.0.20.
       <assert id="PEPPOL-COMMON-R050"
         test="matches(normalize-space(), '^[0-9]{11}$') and u:abn(normalize-space())" flag="fatal">Australian Business Number (ABN) MUST be stated in the correct format.</assert>
     </rule>
+    <rule
+      context="cbc:EndpointID[@schemeID = '0106'] | cac:PartyIdentification/cbc:ID[@schemeID = '0106'] | cbc:CompanyID[@schemeID = '0106']">
+      <assert id="PEPPOL-COMMON-R054"
+        test="matches(normalize-space(), '^[0-9]{8}$')" flag="fatal">Dutch Chamber of Commerce (KVK) numbers (0106) MUST be stated in the correct format (12345678).</assert>
+    </rule>
+    <rule
+      context="cbc:EndpointID[@schemeID = '0190'] | cac:PartyIdentification/cbc:ID[@schemeID = '0190'] | cbc:CompanyID[@schemeID = '0190']">
+      <assert id="PEPPOL-COMMON-R055"
+        test="matches(normalize-space(), '^[0-9]{20}$')" flag="fatal">Dutch organization identification numbers (0190) MUST be stated in the correct format (12345678901234567890).</assert>
+    </rule>
+    <rule
+      context="cbc:EndpointID[@schemeID = '9944'] | cac:PartyIdentification/cbc:ID[@schemeID = '9944'] | cbc:CompanyID[@schemeID = '9944']">
+      <assert id="PEPPOL-COMMON-R056-1"
+        test="matches(normalize-space(), '^NL[0-9]{9}B[0-9]{2}$')" flag="fatal">Dutch VAT numbers (9944) MUST be stated in the correct format (NL123456789B12).</assert>
+    </rule>
+    <!-- If main VAT number starts with NL, validate that too -->
+    <rule context="cac:PartyTaxScheme
+                   [normalize-space(cac:TaxScheme/cbc:ID) = 'VAT']
+                   /cbc:CompanyID
+                   [starts-with(normalize-space(.), 'NL')]">
+    <assert id="PEPPOL-COMMON-R056-2"
+        test="matches(normalize-space(.), '^NL[0-9]{9}B[0-9]{2}$')"
+        flag="fatal">Dutch VAT numbers MUST have the format (NL123456789B12).</assert>
+    </rule>
+    <rule
+      context="cbc:EndpointID[@schemeID = '0217'] | cac:PartyIdentification/cbc:ID[@schemeID = '0217'] | cbc:CompanyID[@schemeID = '0217']">
+      <assert id="PEPPOL-COMMON-R057"
+        test="matches(normalize-space(), '^[0-9]{20}$')" flag="fatal">Dutch Chamber of Commerce Establishment numbers (0217) MUST be stated in the correct format (12345678901234567890).</assert>
+    </rule>
   </pattern>
   <!-- National rules -->
   <pattern>

--- a/rules/sch/PEPPOL-EN16931-UBL.sch
+++ b/rules/sch/PEPPOL-EN16931-UBL.sch
@@ -501,17 +501,17 @@ Last update: 2025 November release 3.0.20.
     <rule
       context="cbc:EndpointID[@schemeID = '0106'] | cac:PartyIdentification/cbc:ID[@schemeID = '0106'] | cbc:CompanyID[@schemeID = '0106']">
       <assert id="PEPPOL-COMMON-R054"
-        test="matches(normalize-space(), '^[0-9]{8}$')" flag="fatal">Dutch Chamber of Commerce (KVK) numbers (0106) MUST be stated in the correct format (12345678).</assert>
+        test="matches(normalize-space(), '^[0-9]{8}$')" flag="warning">Dutch Chamber of Commerce (KVK) numbers (0106) MUST be stated in the correct format (12345678).</assert>
     </rule>
     <rule
       context="cbc:EndpointID[@schemeID = '0190'] | cac:PartyIdentification/cbc:ID[@schemeID = '0190'] | cbc:CompanyID[@schemeID = '0190']">
       <assert id="PEPPOL-COMMON-R055"
-        test="matches(normalize-space(), '^[0-9]{20}$')" flag="fatal">Dutch organization identification numbers (0190) MUST be stated in the correct format (12345678901234567890).</assert>
+        test="matches(normalize-space(), '^[0-9]{20}$')" flag="warning">Dutch organization identification numbers (0190) MUST be stated in the correct format (12345678901234567890).</assert>
     </rule>
     <rule
       context="cbc:EndpointID[@schemeID = '9944'] | cac:PartyIdentification/cbc:ID[@schemeID = '9944'] | cbc:CompanyID[@schemeID = '9944']">
       <assert id="PEPPOL-COMMON-R056-1"
-        test="matches(normalize-space(), '^NL[0-9]{9}B[0-9]{2}$')" flag="fatal">Dutch VAT numbers (9944) MUST be stated in the correct format (NL123456789B12).</assert>
+        test="matches(normalize-space(), '^NL[0-9]{9}B[0-9]{2}$')" flag="warning">Dutch VAT numbers (9944) MUST be stated in the correct format (NL123456789B12).</assert>
     </rule>
     <!-- If main VAT number starts with NL, validate that too -->
     <rule context="cac:PartyTaxScheme
@@ -520,12 +520,12 @@ Last update: 2025 November release 3.0.20.
                    [starts-with(normalize-space(.), 'NL')]">
     <assert id="PEPPOL-COMMON-R056-2"
         test="matches(normalize-space(.), '^NL[0-9]{9}B[0-9]{2}$')"
-        flag="fatal">Dutch VAT numbers MUST have the format (NL123456789B12).</assert>
+        flag="warning">Dutch VAT numbers MUST have the format (NL123456789B12).</assert>
     </rule>
     <rule
       context="cbc:EndpointID[@schemeID = '0217'] | cac:PartyIdentification/cbc:ID[@schemeID = '0217'] | cbc:CompanyID[@schemeID = '0217']">
       <assert id="PEPPOL-COMMON-R057"
-        test="matches(normalize-space(), '^[0-9]{20}$')" flag="fatal">Dutch Chamber of Commerce Establishment numbers (0217) MUST be stated in the correct format (12345678901234567890).</assert>
+        test="matches(normalize-space(), '^[0-9]{20}$')" flag="warning">Dutch Chamber of Commerce Establishment numbers (0217) MUST be stated in the correct format (12345678901234567890).</assert>
     </rule>
   </pattern>
   <!-- National rules -->

--- a/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R054.xml
+++ b/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R054.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-cii">
+  <assert>
+    <description>ICD 0106 (Dutch KVK) Format check.</description>
+    <scope>PEPPOL-COMMON-R054</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R054</success>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">12345678</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">87654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <!-- Error cases: URIID for supplier and customer, non-digit characters, too few characters, and too many characters -->
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">X123456X</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">X123456X</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">7777777</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">7777777</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">999999999</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0106">999999999</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+
+</testSet>

--- a/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R054.xml
+++ b/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R054.xml
@@ -31,7 +31,7 @@
   <!-- Error cases: URIID for supplier and customer, non-digit characters, too few characters, and too many characters -->
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -50,7 +50,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -69,7 +69,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -88,7 +88,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -107,7 +107,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -126,7 +126,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>

--- a/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R055.xml
+++ b/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R055.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-cii">
+  <assert>
+    <description>ICD 0190 (Dutch Organization Identifier) Format check.</description>
+    <scope>PEPPOL-COMMON-R055</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R055</success>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0190">12345678901234567890</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0190">09876543210987654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <!-- Error cases: URIID for supplier and customer, non-digit characters, too few characters, and too many characters -->
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0190">X234567890123456789X</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0190">X234567890123456789X</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0190">1919191919191919191</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0190">1919191919191919191</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0190">212121212121212121212</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0190">212121212121212121212</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+
+</testSet>

--- a/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R055.xml
+++ b/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R055.xml
@@ -31,7 +31,7 @@
   <!-- Error cases: URIID for supplier and customer, non-digit characters, too few characters, and too many characters -->
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -50,7 +50,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -69,7 +69,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -88,7 +88,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -107,7 +107,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -126,7 +126,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>

--- a/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R056-1.xml
+++ b/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R056-1.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-cii">
+  <assert>
+    <description>Scheme 9944 (Dutch VAT) Format check.</description>
+    <scope>PEPPOL-COMMON-R056-1</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R056-1</success>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="9944">NL123456789B01</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="9944">NL123456789B02</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <!-- Error cases: URIID for supplier and customer, non-digit characters, too few characters, and too many characters -->
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="9944">NL123456789A01</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="9944">DE123456789B01</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="9944">NL123456789A01</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="9944">NL88888888B01</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="9944">NL88888888B01</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="9944">NL10101010B01</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="9944">NL10101010B01</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R056-1.xml
+++ b/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R056-1.xml
@@ -31,7 +31,7 @@
   <!-- Error cases: URIID for supplier and customer, non-digit characters, too few characters, and too many characters -->
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -50,7 +50,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -69,7 +69,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -88,7 +88,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -107,7 +107,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -126,7 +126,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -145,7 +145,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>

--- a/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R057.xml
+++ b/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R057.xml
@@ -31,7 +31,7 @@
   <!-- Error cases: URIID for supplier and customer, non-digit characters, too few characters, and too many characters -->
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -50,7 +50,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -69,7 +69,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -88,7 +88,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -107,7 +107,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>
@@ -126,7 +126,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <rsm:ExchangedDocument>

--- a/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R057.xml
+++ b/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R057.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-cii">
+  <assert>
+    <description>ICD 0217 (Dutch KVK Establishment Number) Format check.</description>
+    <scope>PEPPOL-COMMON-R057</scope>
+  </assert>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R057</success>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0217">12345678901234567890</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0217">09876543210987654321</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <!-- Error cases: URIID for supplier and customer, non-digit characters, too few characters, and too many characters -->
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0217">X234567890123456789X</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0217">X234567890123456789X</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0217">1919191919191919191</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0217">1919191919191919191</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:SellerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0217">212121212121212121212</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:SellerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <rsm:ExchangedDocument>
+        <ram:TypeCode>380</ram:TypeCode>
+      </rsm:ExchangedDocument>
+      <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+          <ram:BuyerTradeParty>
+            <ram:URIUniversalCommunication>
+              <ram:URIID schemeID="0217">212121212121212121212</ram:URIID>
+            </ram:URIUniversalCommunication>
+          </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      </rsm:SupplyChainTradeTransaction>
+    </rsm:CrossIndustryInvoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R054.xml
+++ b/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R054.xml
@@ -84,7 +84,7 @@
   <!-- Failure cases: EndpointID, PartyIdentification, and CompanyID with schemeID="0106", with non-allowed characters, not enough characters, and too many characters, for both AccountingSupplierParty and AccountingCustomerParty -->
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -96,7 +96,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -110,7 +110,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -122,7 +122,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -134,7 +134,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -148,7 +148,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -160,7 +160,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -172,7 +172,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -186,7 +186,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -198,7 +198,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -210,7 +210,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -224,7 +224,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -236,7 +236,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -248,7 +248,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -262,7 +262,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -274,7 +274,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -286,7 +286,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -300,7 +300,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R054</error>
+      <warning>PEPPOL-COMMON-R054</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>

--- a/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R054.xml
+++ b/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R054.xml
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+    <description>ICD 0106 (Dutch KVK) Format check.</description>
+    <scope>PEPPOL-COMMON-R054</scope>
+  </assert>
+  <!-- Success cases: EndpointID, PartyIdentification, and CompanyID with schemeID="0106", for both AccountingSupplierParty and AccountingCustomerParty -->
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R054</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R054</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0106">12345678</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R054</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R054</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">12345678</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R054</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0106">12345678</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R054</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0106">12345678</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <!-- Failure cases: EndpointID, PartyIdentification, and CompanyID with schemeID="0106", with non-allowed characters, not enough characters, and too many characters, for both AccountingSupplierParty and AccountingCustomerParty -->
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">X123456X</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0106">X123456X</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0106">X123456X</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">7777777</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0106">7777777</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0106">7777777</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">999999999</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0106">999999999</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0106">999999999</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">X123456X</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0106">X123456X</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0106">X123456X</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">7777777</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0106">7777777</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0106">7777777</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0106">999999999</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0106">999999999</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R054</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0106">999999999</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R055.xml
+++ b/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R055.xml
@@ -84,7 +84,7 @@
   <!-- Failure cases: EndpointID, PartyIdentification, and CompanyID with schemeID="0190", with non-allowed characters, not enough characters, and too many characters, for both AccountingSupplierParty and AccountingCustomerParty -->
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -96,7 +96,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -110,7 +110,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -122,7 +122,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -134,7 +134,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -148,7 +148,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -160,7 +160,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -172,7 +172,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -186,7 +186,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -198,7 +198,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -210,7 +210,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -224,7 +224,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -236,7 +236,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -248,7 +248,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -262,7 +262,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -274,7 +274,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -286,7 +286,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -300,7 +300,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R055</error>
+      <warning>PEPPOL-COMMON-R055</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>

--- a/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R055.xml
+++ b/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R055.xml
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+    <description>ICD 0190 (Dutch OIN) Format check.</description>
+    <scope>PEPPOL-COMMON-R055</scope>
+  </assert>
+  <!-- Success cases: EndpointID, PartyIdentification, and CompanyID with schemeID="0190", for both AccountingSupplierParty and AccountingCustomerParty -->
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R055</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0190">12345678901234567890</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R055</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0190">12345678901234567890</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R055</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0190">12345678901234567890</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R055</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0190">12345678901234567890</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R055</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0190">12345678901234567890</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R055</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0190">12345678901234567890</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <!-- Failure cases: EndpointID, PartyIdentification, and CompanyID with schemeID="0190", with non-allowed characters, not enough characters, and too many characters, for both AccountingSupplierParty and AccountingCustomerParty -->
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0190">X234567890123456789X</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0190">X234567890123456789X</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0190">X234567890123456789X</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0190">1919191919191919191</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0190">1919191919191919191</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0190">1919191919191919191</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0190">212121212121212121212</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0190">212121212121212121212</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0190">212121212121212121212</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0190">X234567890123456789X</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0190">X234567890123456789X</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0190">X234567890123456789X</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0190">1919191919191919191</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0190">1919191919191919191</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0190">1919191919191919191</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0190">212121212121212121212</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0190">212121212121212121212</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R055</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0190">212121212121212121212</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R056-1.xml
+++ b/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R056-1.xml
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+    <description>Scheme 9944 (Dutch VAT) Format check.</description>
+    <scope>PEPPOL-COMMON-R056-1</scope>
+  </assert>
+  <!-- Success cases: EndpointID, PartyIdentification, and CompanyID with schemeID="9944", for both AccountingSupplierParty and AccountingCustomerParty -->
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R056-1</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="9944">NL123456789B01</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R056-1</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="9944">NL123456789B01</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R056-1</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="9944">NL123456789B01</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R056-1</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="9944">NL123456789B01</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R056-1</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="9944">NL123456789B01</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R056-1</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="9944">NL123456789B01</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <!-- Failure cases: EndpointID, PartyIdentification, and CompanyID with schemeID="9944", with non-allowed characters, not enough characters, and too many characters, for both AccountingSupplierParty and AccountingCustomerParty. One additional check: NL prefix -->
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="9944">NL123456789A01</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="9944">DE123456789B01</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="9944">NL123456789A01</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="9944">NL123456789A01</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="9944">NL12345678B01</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="9944">NL12345678B01</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="9944">NL12345678B01</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="9944">NL1010101010B01</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="9944">NL1010101010B01</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="9944">NL1010101010B01</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="9944">NL123456789A01</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="9944">NL123456789A01</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="9944">NL123456789A01</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="9944">NL12345678B01</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="9944">NL12345678B01</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="9944">NL12345678B01</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="9944">NL1010101010B01</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="9944">NL1010101010B01</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R056-1</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="9944">NL1010101010B01</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R056-1.xml
+++ b/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R056-1.xml
@@ -84,7 +84,7 @@
   <!-- Failure cases: EndpointID, PartyIdentification, and CompanyID with schemeID="9944", with non-allowed characters, not enough characters, and too many characters, for both AccountingSupplierParty and AccountingCustomerParty. One additional check: NL prefix -->
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -96,7 +96,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -108,7 +108,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -122,7 +122,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -134,7 +134,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -146,7 +146,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -160,7 +160,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -172,7 +172,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -184,7 +184,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -198,7 +198,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -210,7 +210,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -222,7 +222,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -236,7 +236,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -248,7 +248,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -260,7 +260,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -274,7 +274,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -286,7 +286,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -298,7 +298,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -312,7 +312,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R056-1</error>
+      <warning>PEPPOL-COMMON-R056-1</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>

--- a/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R057.xml
+++ b/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R057.xml
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+    <description>ICD 0217 (Dutch KVK Establishment number) Format check.</description>
+    <scope>PEPPOL-COMMON-R057</scope>
+  </assert>
+  <!-- Success cases: EndpointID, PartyIdentification, and CompanyID with schemeID="0217", for both AccountingSupplierParty and AccountingCustomerParty -->
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R057</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0217">12345678901234567890</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R057</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0217">12345678901234567890</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R057</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0217">12345678901234567890</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R057</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0217">12345678901234567890</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R057</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0217">12345678901234567890</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <success>PEPPOL-COMMON-R057</success>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0217">12345678901234567890</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <!-- Failure cases: EndpointID, PartyIdentification, and CompanyID with schemeID="0217", with non-allowed characters, not enough characters, and too many characters, for both AccountingSupplierParty and AccountingCustomerParty -->
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0217">X234567890123456789X</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0217">X234567890123456789X</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0217">X234567890123456789X</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0217">1919191919191919191</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0217">1919191919191919191</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0217">1919191919191919191</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0217">212121212121212121212</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0217">212121212121212121212</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0217">212121212121212121212</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0217">X234567890123456789X</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0217">X234567890123456789X</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0217">X234567890123456789X</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0217">1919191919191919191</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0217">1919191919191919191</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0217">1919191919191919191</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0217">212121212121212121212</cbc:EndpointID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0217">212121212121212121212</cbc:ID>
+          </cac:PartyIdentification>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+  <test>
+    <assert>
+      <error>PEPPOL-COMMON-R057</error>
+    </assert>
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:CompanyID schemeID="0217">212121212121212121212</cbc:CompanyID>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+  </test>
+</testSet>

--- a/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R057.xml
+++ b/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R057.xml
@@ -84,7 +84,7 @@
   <!-- Failure cases: EndpointID, PartyIdentification, and CompanyID with schemeID="0217", with non-allowed characters, not enough characters, and too many characters, for both AccountingSupplierParty and AccountingCustomerParty -->
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -96,7 +96,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -110,7 +110,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -122,7 +122,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -134,7 +134,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -148,7 +148,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -160,7 +160,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -172,7 +172,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -186,7 +186,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
@@ -198,7 +198,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -210,7 +210,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -224,7 +224,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -236,7 +236,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -248,7 +248,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -262,7 +262,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -274,7 +274,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -286,7 +286,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
@@ -300,7 +300,7 @@
   </test>
   <test>
     <assert>
-      <error>PEPPOL-COMMON-R057</error>
+      <warning>PEPPOL-COMMON-R057</warning>
     </assert>
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>


### PR DESCRIPTION
… and NL VAT numbers.

This commit adds the following checks:
- PEPPOL-COMMON-R054: Identifiers with scheme 0106 should be 8 digits
- PEPPOL-COMMON-R055: Identifiers with scheme 0190 should be 20 digits
- PEPPOL-COMMON-R056-1: Identifiers with scheme 9944 should have the format NL123456789B12
- PEPPOL-COMMON-R056-2: VAT identifiers starting with NL should have the format NL123456789B12
- PEPPOL-COMMON-R057: Identifiers with scheme 0217 should be 20 digits

This has been implemented for UBL as well as CII, and each rule has a new unit test file associated with it.