### PR TITLE
Identifiers nl fix est numbers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
-= PEPPOL BIS Billing 3.0
+= Peppol BIS Billing 3.0
 
-This repository contains the resources making up PEPPOL BIS Billing 3.0.
+This repository contains the resources making up Peppol BIS Billing 3.0.
 
 Please use our link:https://openpeppol.atlassian.net/servicedesk/customer/portal/1[Service desk] to report any issues related to the specification.

--- a/guide/bis/settings.adoc
+++ b/guide/bis/settings.adoc
@@ -3,7 +3,7 @@
 :doctitle: image:../shared/images/peppol.jpg[float="right", width=100%] Peppol BIS Billing
 :shared-dir: ../../shared
 :snippet-dir: ../../rules/snippets
-:version: 3.0.18
+:version: 3.0.20
 :name-op-en: OpenPeppol AISBL, Post-Award Coordinating Community
 
 

--- a/rules/sch/PEPPOL-EN16931-CII.sch
+++ b/rules/sch/PEPPOL-EN16931-CII.sch
@@ -232,7 +232,7 @@ Last update: 2026 May release 3.0.21.
       <assert id="PEPPOL-COMMON-R056-2" test="matches(normalize-space(.), '^NL[0-9]{9}B[0-9]{2}$')" flag="warning">[PEPPOL-COMMON-R056-2]-Dutch VAT numbers MUST have the format (NL123456789B12).</assert>
     </rule>
 	<rule context="ram:URIID[@schemeID = '0217'] | ram:ID[@schemeID = '0217'] | ram:GlobalID[@schemeID = '0217']">
-      <assert id="PEPPOL-COMMON-R057" test="matches(normalize-space(), '^[0-9]{20}$')" flag="warning">[PEPPOL-COMMON-R057]-Dutch Chamber of Commerce Establishment numbers (0217) MUST be stated in the correct format (12345678901234567890).</assert>
+      <assert id="PEPPOL-COMMON-R057" test="matches(normalize-space(), '^[0-9]{12}$')" flag="warning">[PEPPOL-COMMON-R057]-Dutch Chamber of Commerce Establishment numbers (0217) MUST be stated in the correct format (123456789012).</assert>
     </rule>
 <!--
 -->

--- a/rules/sch/PEPPOL-EN16931-UBL.sch
+++ b/rules/sch/PEPPOL-EN16931-UBL.sch
@@ -273,7 +273,7 @@ Last update: 2026 May release 3.0.21.
     <assert id="PEPPOL-COMMON-R056-2" test="matches(normalize-space(.), '^NL[0-9]{9}B[0-9]{2}$')" flag="warning">[PEPPOL-COMMON-R056-2]-Dutch VAT numbers MUST have the format (NL123456789B12).</assert>
     </rule>
     <rule context="cbc:EndpointID[@schemeID = '0217'] | cac:PartyIdentification/cbc:ID[@schemeID = '0217'] | cbc:CompanyID[@schemeID = '0217']">
-      <assert id="PEPPOL-COMMON-R057" test="matches(normalize-space(), '^[0-9]{20}$')" flag="warning">[PEPPOL-COMMON-R057]-Dutch Chamber of Commerce Establishment numbers (0217) MUST be stated in the correct format (12345678901234567890).</assert>
+      <assert id="PEPPOL-COMMON-R057" test="matches(normalize-space(), '^[0-9]{12}$')" flag="warning">[PEPPOL-COMMON-R057]-Dutch Chamber of Commerce Establishment numbers (0217) MUST be stated in the correct format (123456789012).</assert>
     </rule>
   </pattern>
   <!-- National rules -->

--- a/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R057.xml
+++ b/rules/unit-CII-PEPPOL/PEPPOL-COMMON-R057.xml
@@ -16,12 +16,12 @@
         <ram:ApplicableHeaderTradeAgreement>
           <ram:SellerTradeParty>
             <ram:URIUniversalCommunication>
-              <ram:URIID schemeID="0217">12345678901234567890</ram:URIID>
+              <ram:URIID schemeID="0217">123456789012</ram:URIID>
             </ram:URIUniversalCommunication>
           </ram:SellerTradeParty>
           <ram:BuyerTradeParty>
             <ram:URIUniversalCommunication>
-              <ram:URIID schemeID="0217">09876543210987654321</ram:URIID>
+              <ram:URIID schemeID="0217">098765432112</ram:URIID>
             </ram:URIUniversalCommunication>
           </ram:BuyerTradeParty>
         </ram:ApplicableHeaderTradeAgreement>
@@ -41,7 +41,7 @@
         <ram:ApplicableHeaderTradeAgreement>
           <ram:SellerTradeParty>
             <ram:URIUniversalCommunication>
-              <ram:URIID schemeID="0217">X234567890123456789X</ram:URIID>
+              <ram:URIID schemeID="0217">X9876543211X</ram:URIID>
             </ram:URIUniversalCommunication>
           </ram:SellerTradeParty>
         </ram:ApplicableHeaderTradeAgreement>
@@ -60,7 +60,7 @@
         <ram:ApplicableHeaderTradeAgreement>
           <ram:BuyerTradeParty>
             <ram:URIUniversalCommunication>
-              <ram:URIID schemeID="0217">X234567890123456789X</ram:URIID>
+              <ram:URIID schemeID="0217">X9876543211X</ram:URIID>
             </ram:URIUniversalCommunication>
           </ram:BuyerTradeParty>
         </ram:ApplicableHeaderTradeAgreement>
@@ -79,7 +79,7 @@
         <ram:ApplicableHeaderTradeAgreement>
           <ram:SellerTradeParty>
             <ram:URIUniversalCommunication>
-              <ram:URIID schemeID="0217">1919191919191919191</ram:URIID>
+              <ram:URIID schemeID="0217">12345678901</ram:URIID>
             </ram:URIUniversalCommunication>
           </ram:SellerTradeParty>
         </ram:ApplicableHeaderTradeAgreement>
@@ -98,7 +98,7 @@
         <ram:ApplicableHeaderTradeAgreement>
           <ram:BuyerTradeParty>
             <ram:URIUniversalCommunication>
-              <ram:URIID schemeID="0217">1919191919191919191</ram:URIID>
+              <ram:URIID schemeID="0217">12345678901</ram:URIID>
             </ram:URIUniversalCommunication>
           </ram:BuyerTradeParty>
         </ram:ApplicableHeaderTradeAgreement>
@@ -117,7 +117,7 @@
         <ram:ApplicableHeaderTradeAgreement>
           <ram:SellerTradeParty>
             <ram:URIUniversalCommunication>
-              <ram:URIID schemeID="0217">212121212121212121212</ram:URIID>
+              <ram:URIID schemeID="0217">1234567890123</ram:URIID>
             </ram:URIUniversalCommunication>
           </ram:SellerTradeParty>
         </ram:ApplicableHeaderTradeAgreement>
@@ -136,7 +136,7 @@
         <ram:ApplicableHeaderTradeAgreement>
           <ram:BuyerTradeParty>
             <ram:URIUniversalCommunication>
-              <ram:URIID schemeID="0217">212121212121212121212</ram:URIID>
+              <ram:URIID schemeID="0217">1234567890123</ram:URIID>
             </ram:URIUniversalCommunication>
           </ram:BuyerTradeParty>
         </ram:ApplicableHeaderTradeAgreement>

--- a/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R057.xml
+++ b/rules/unit-UBL-PEPPOL/PEPPOL-COMMON-R057.xml
@@ -12,7 +12,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
         <cac:Party>
-          <cbc:EndpointID schemeID="0217">12345678901234567890</cbc:EndpointID>
+          <cbc:EndpointID schemeID="0217">123456789012</cbc:EndpointID>
         </cac:Party>
       </cac:AccountingCustomerParty>
     </Invoice>
@@ -25,7 +25,7 @@
       <cac:AccountingCustomerParty>
         <cac:Party>
           <cac:PartyIdentification>
-            <cbc:ID schemeID="0217">12345678901234567890</cbc:ID>
+            <cbc:ID schemeID="0217">123456789012</cbc:ID>
           </cac:PartyIdentification>
         </cac:Party>
       </cac:AccountingCustomerParty>
@@ -38,7 +38,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
         <cac:Party>
-          <cbc:CompanyID schemeID="0217">12345678901234567890</cbc:CompanyID>
+          <cbc:CompanyID schemeID="0217">123456789012</cbc:CompanyID>
         </cac:Party>
       </cac:AccountingCustomerParty>
     </Invoice>
@@ -50,7 +50,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
         <cac:Party>
-          <cbc:EndpointID schemeID="0217">12345678901234567890</cbc:EndpointID>
+          <cbc:EndpointID schemeID="0217">123456789012</cbc:EndpointID>
         </cac:Party>
       </cac:AccountingSupplierParty>
     </Invoice>
@@ -63,7 +63,7 @@
       <cac:AccountingSupplierParty>
         <cac:Party>
           <cac:PartyIdentification>
-            <cbc:ID schemeID="0217">12345678901234567890</cbc:ID>
+            <cbc:ID schemeID="0217">123456789012</cbc:ID>
           </cac:PartyIdentification>
         </cac:Party>
       </cac:AccountingSupplierParty>
@@ -76,7 +76,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
         <cac:Party>
-          <cbc:CompanyID schemeID="0217">12345678901234567890</cbc:CompanyID>
+          <cbc:CompanyID schemeID="0217">123456789012</cbc:CompanyID>
         </cac:Party>
       </cac:AccountingSupplierParty>
     </Invoice>
@@ -89,7 +89,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
         <cac:Party>
-          <cbc:EndpointID schemeID="0217">X234567890123456789X</cbc:EndpointID>
+          <cbc:EndpointID schemeID="0217">X9876543211X</cbc:EndpointID>
         </cac:Party>
       </cac:AccountingCustomerParty>
     </Invoice>
@@ -102,7 +102,7 @@
       <cac:AccountingCustomerParty>
         <cac:Party>
           <cac:PartyIdentification>
-            <cbc:ID schemeID="0217">X234567890123456789X</cbc:ID>
+            <cbc:ID schemeID="0217">X9876543211X</cbc:ID>
           </cac:PartyIdentification>
         </cac:Party>
       </cac:AccountingCustomerParty>
@@ -115,7 +115,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
         <cac:Party>
-          <cbc:CompanyID schemeID="0217">X234567890123456789X</cbc:CompanyID>
+          <cbc:CompanyID schemeID="0217">X9876543211X</cbc:CompanyID>
         </cac:Party>
       </cac:AccountingCustomerParty>
     </Invoice>
@@ -127,7 +127,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
         <cac:Party>
-          <cbc:EndpointID schemeID="0217">1919191919191919191</cbc:EndpointID>
+          <cbc:EndpointID schemeID="0217">12345678901</cbc:EndpointID>
         </cac:Party>
       </cac:AccountingCustomerParty>
     </Invoice>
@@ -140,7 +140,7 @@
       <cac:AccountingCustomerParty>
         <cac:Party>
           <cac:PartyIdentification>
-            <cbc:ID schemeID="0217">1919191919191919191</cbc:ID>
+            <cbc:ID schemeID="0217">12345678901</cbc:ID>
           </cac:PartyIdentification>
         </cac:Party>
       </cac:AccountingCustomerParty>
@@ -153,7 +153,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
         <cac:Party>
-          <cbc:CompanyID schemeID="0217">1919191919191919191</cbc:CompanyID>
+          <cbc:CompanyID schemeID="0217">12345678901</cbc:CompanyID>
         </cac:Party>
       </cac:AccountingCustomerParty>
     </Invoice>
@@ -165,7 +165,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
         <cac:Party>
-          <cbc:EndpointID schemeID="0217">212121212121212121212</cbc:EndpointID>
+          <cbc:EndpointID schemeID="0217">1234567890123</cbc:EndpointID>
         </cac:Party>
       </cac:AccountingCustomerParty>
     </Invoice>
@@ -178,7 +178,7 @@
       <cac:AccountingCustomerParty>
         <cac:Party>
           <cac:PartyIdentification>
-            <cbc:ID schemeID="0217">212121212121212121212</cbc:ID>
+            <cbc:ID schemeID="0217">1234567890123</cbc:ID>
           </cac:PartyIdentification>
         </cac:Party>
       </cac:AccountingCustomerParty>
@@ -191,7 +191,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingCustomerParty>
         <cac:Party>
-          <cbc:CompanyID schemeID="0217">212121212121212121212</cbc:CompanyID>
+          <cbc:CompanyID schemeID="0217">1234567890123</cbc:CompanyID>
         </cac:Party>
       </cac:AccountingCustomerParty>
     </Invoice>
@@ -203,7 +203,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
         <cac:Party>
-          <cbc:EndpointID schemeID="0217">X234567890123456789X</cbc:EndpointID>
+          <cbc:EndpointID schemeID="0217">X9876543211X</cbc:EndpointID>
         </cac:Party>
       </cac:AccountingSupplierParty>
     </Invoice>
@@ -216,7 +216,7 @@
       <cac:AccountingSupplierParty>
         <cac:Party>
           <cac:PartyIdentification>
-            <cbc:ID schemeID="0217">X234567890123456789X</cbc:ID>
+            <cbc:ID schemeID="0217">X9876543211X</cbc:ID>
           </cac:PartyIdentification>
         </cac:Party>
       </cac:AccountingSupplierParty>
@@ -229,7 +229,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
         <cac:Party>
-          <cbc:CompanyID schemeID="0217">X234567890123456789X</cbc:CompanyID>
+          <cbc:CompanyID schemeID="0217">X9876543211X</cbc:CompanyID>
         </cac:Party>
       </cac:AccountingSupplierParty>
     </Invoice>
@@ -241,7 +241,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
         <cac:Party>
-          <cbc:EndpointID schemeID="0217">1919191919191919191</cbc:EndpointID>
+          <cbc:EndpointID schemeID="0217">12345678901</cbc:EndpointID>
         </cac:Party>
       </cac:AccountingSupplierParty>
     </Invoice>
@@ -254,7 +254,7 @@
       <cac:AccountingSupplierParty>
         <cac:Party>
           <cac:PartyIdentification>
-            <cbc:ID schemeID="0217">1919191919191919191</cbc:ID>
+            <cbc:ID schemeID="0217">12345678901</cbc:ID>
           </cac:PartyIdentification>
         </cac:Party>
       </cac:AccountingSupplierParty>
@@ -267,7 +267,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
         <cac:Party>
-          <cbc:CompanyID schemeID="0217">1919191919191919191</cbc:CompanyID>
+          <cbc:CompanyID schemeID="0217">12345678901</cbc:CompanyID>
         </cac:Party>
       </cac:AccountingSupplierParty>
     </Invoice>
@@ -279,7 +279,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
         <cac:Party>
-          <cbc:EndpointID schemeID="0217">212121212121212121212</cbc:EndpointID>
+          <cbc:EndpointID schemeID="0217">1234567890123</cbc:EndpointID>
         </cac:Party>
       </cac:AccountingSupplierParty>
     </Invoice>
@@ -292,7 +292,7 @@
       <cac:AccountingSupplierParty>
         <cac:Party>
           <cac:PartyIdentification>
-            <cbc:ID schemeID="0217">212121212121212121212</cbc:ID>
+            <cbc:ID schemeID="0217">1234567890123</cbc:ID>
           </cac:PartyIdentification>
         </cac:Party>
       </cac:AccountingSupplierParty>
@@ -305,7 +305,7 @@
     <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
       <cac:AccountingSupplierParty>
         <cac:Party>
-          <cbc:CompanyID schemeID="0217">212121212121212121212</cbc:CompanyID>
+          <cbc:CompanyID schemeID="0217">1234567890123</cbc:CompanyID>
         </cac:Party>
       </cac:AccountingSupplierParty>
     </Invoice>


### PR DESCRIPTION
The previous PR set the number of digits to 20, which was wrong; it should be 12 (despite the description in the ISO 6523 ICD list). This PR should fix that.

Note that the build scripts appear to be broken (they fail on some unverifiable signature), so I was not able to run the unit tests.