### PR TITLE
Slovak domestic mandatory BT rules for Peppol BIS Billing 3.0 (SK)

### DIFF
--- a/DMF-target-branch.patch
+++ b/DMF-target-branch.patch
@@ -1,0 +1,898 @@
+diff --git a/rules/sch/PEPPOL-EN16931-UBL.sch b/rules/sch/PEPPOL-EN16931-UBL.sch
+index 17b0540..8123251 100644
+--- a/rules/sch/PEPPOL-EN16931-UBL.sch
++++ b/rules/sch/PEPPOL-EN16931-UBL.sch
+@@ -436,6 +436,21 @@ Last update: 2026 May release 3.0.21.
+     </rule>
+   </pattern>
+   <!-- National rules -->
++  <!-- SLOVAKIA -->
++  <pattern>
++    <let name="SKSupplierCountry" value="upper-case(normalize-space(/*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode))" />
++    <let name="SKCustomerCountry" value="upper-case(normalize-space(/*/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode))" />
++    <rule context="cac:AccountingSupplierParty/cac:Party/cac:PostalAddress[$SKSupplierCountry = 'SK' and $SKCustomerCountry = 'SK']">
++      <assert id="SK-R-002" test="cbc:StreetName" flag="warning">[SK-R-002]-For domestic Slovak transactions, BT-35 Seller street name shall be provided.</assert>
++      <assert id="SK-R-003" test="cbc:CityName" flag="warning">[SK-R-003]-For domestic Slovak transactions, BT-37 Seller city name shall be provided.</assert>
++      <assert id="SK-R-004" test="cbc:PostalZone" flag="warning">[SK-R-004]-For domestic Slovak transactions, BT-38 Seller postal code shall be provided.</assert>
++    </rule>
++    <rule context="cac:AccountingCustomerParty/cac:Party/cac:PostalAddress[$SKSupplierCountry = 'SK' and $SKCustomerCountry = 'SK']">
++      <assert id="SK-R-005" test="cbc:StreetName" flag="warning">[SK-R-005]-For domestic Slovak transactions, BT-50 Buyer street name shall be provided.</assert>
++      <assert id="SK-R-006" test="cbc:CityName" flag="warning">[SK-R-006]-For domestic Slovak transactions, BT-52 Buyer city name shall be provided.</assert>
++      <assert id="SK-R-007" test="cbc:PostalZone" flag="warning">[SK-R-007]-For domestic Slovak transactions, BT-53 Buyer postal code shall be provided.</assert>
++    </rule>
++  </pattern>
+   <pattern>
+     <!-- NORWAY -->
+     <rule context="cac:AccountingSupplierParty/cac:Party[$supplierCountry = 'NO']">
+diff --git a/rules/unit-UBL-SK/UBL-IN_SK-DMF.xml b/rules/unit-UBL-SK/UBL-IN_SK-DMF.xml
+new file mode 100644
+index 0000000..28ed029
+--- /dev/null
++++ b/rules/unit-UBL-SK/UBL-IN_SK-DMF.xml
+@@ -0,0 +1,866 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0"
++         configuration="peppolbis-en16931-base-3.0-ubl">
++  <assert>
++    <description>Slovak domestic invoices should provide the agreed seller and buyer address fields when BT-40 and BT-55 are both SK.</description>
++    <scope>SK-R-002</scope>
++    <scope>SK-R-003</scope>
++    <scope>SK-R-004</scope>
++    <scope>SK-R-005</scope>
++    <scope>SK-R-006</scope>
++    <scope>SK-R-007</scope>
++  </assert>
++
++  <test>
++    <assert>
++      <success>SK-R-002</success>
++      <success>SK-R-003</success>
++      <success>SK-R-004</success>
++      <success>SK-R-005</success>
++      <success>SK-R-006</success>
++      <success>SK-R-007</success>
++    </assert>
++    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
++      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
++      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
++      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
++      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
++      <cbc:ID>SK-DMF-POS-001</cbc:ID>
++      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
++      <cbc:DueDate>2026-08-20</cbc:DueDate>
++      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
++      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
++      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
++      <cac:AccountingSupplierParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
++            <cbc:CityName>Bratislava</cbc:CityName>
++            <cbc:PostalZone>811 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyTaxScheme>
++            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:PartyTaxScheme>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
++            <cbc:CompanyID>12345678</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingSupplierParty>
++      <cac:AccountingCustomerParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
++            <cbc:CityName>Kosice</cbc:CityName>
++            <cbc:PostalZone>040 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
++            <cbc:CompanyID>87654321</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingCustomerParty>
++      <cac:PaymentMeans>
++        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
++        <cbc:PaymentID>SK-DMF-POS-001</cbc:PaymentID>
++        <cac:PayeeFinancialAccount>
++          <cbc:ID>SK3112000000198742637541</cbc:ID>
++        </cac:PayeeFinancialAccount>
++      </cac:PaymentMeans>
++      <cac:TaxTotal>
++        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++        <cac:TaxSubtotal>
++          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
++          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++          <cac:TaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:TaxCategory>
++        </cac:TaxSubtotal>
++      </cac:TaxTotal>
++      <cac:LegalMonetaryTotal>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
++        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
++        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
++      </cac:LegalMonetaryTotal>
++      <cac:InvoiceLine>
++        <cbc:ID>1</cbc:ID>
++        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cac:Item>
++          <cbc:Name>Test service</cbc:Name>
++          <cac:ClassifiedTaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:ClassifiedTaxCategory>
++        </cac:Item>
++        <cac:Price>
++          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
++        </cac:Price>
++      </cac:InvoiceLine>
++    </Invoice>
++  </test>
++
++  <test>
++    <assert>
++      <warning>SK-R-002</warning>
++      <success>SK-R-003</success>
++      <success>SK-R-004</success>
++      <success>SK-R-005</success>
++      <success>SK-R-006</success>
++      <success>SK-R-007</success>
++    </assert>
++    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
++      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
++      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
++      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
++      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
++      <cbc:ID>SK-DMF-NEG-001</cbc:ID>
++      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
++      <cbc:DueDate>2026-08-20</cbc:DueDate>
++      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
++      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
++      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
++      <cac:AccountingSupplierParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:CityName>Bratislava</cbc:CityName>
++            <cbc:PostalZone>811 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyTaxScheme>
++            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:PartyTaxScheme>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
++            <cbc:CompanyID>12345678</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingSupplierParty>
++      <cac:AccountingCustomerParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
++            <cbc:CityName>Kosice</cbc:CityName>
++            <cbc:PostalZone>040 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
++            <cbc:CompanyID>87654321</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingCustomerParty>
++      <cac:PaymentMeans>
++        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
++        <cbc:PaymentID>SK-DMF-NEG-001</cbc:PaymentID>
++        <cac:PayeeFinancialAccount>
++          <cbc:ID>SK3112000000198742637541</cbc:ID>
++        </cac:PayeeFinancialAccount>
++      </cac:PaymentMeans>
++      <cac:TaxTotal>
++        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++        <cac:TaxSubtotal>
++          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
++          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++          <cac:TaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:TaxCategory>
++        </cac:TaxSubtotal>
++      </cac:TaxTotal>
++      <cac:LegalMonetaryTotal>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
++        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
++        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
++      </cac:LegalMonetaryTotal>
++      <cac:InvoiceLine>
++        <cbc:ID>1</cbc:ID>
++        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cac:Item>
++          <cbc:Name>Test service</cbc:Name>
++          <cac:ClassifiedTaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:ClassifiedTaxCategory>
++        </cac:Item>
++        <cac:Price>
++          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
++        </cac:Price>
++      </cac:InvoiceLine>
++    </Invoice>
++  </test>
++
++  <test>
++    <assert>
++      <success>SK-R-002</success>
++      <warning>SK-R-003</warning>
++      <success>SK-R-004</success>
++      <success>SK-R-005</success>
++      <success>SK-R-006</success>
++      <success>SK-R-007</success>
++    </assert>
++    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
++      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
++      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
++      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
++      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
++      <cbc:ID>SK-DMF-NEG-002</cbc:ID>
++      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
++      <cbc:DueDate>2026-08-20</cbc:DueDate>
++      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
++      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
++      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
++      <cac:AccountingSupplierParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
++            <cbc:PostalZone>811 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyTaxScheme>
++            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:PartyTaxScheme>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
++            <cbc:CompanyID>12345678</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingSupplierParty>
++      <cac:AccountingCustomerParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
++            <cbc:CityName>Kosice</cbc:CityName>
++            <cbc:PostalZone>040 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
++            <cbc:CompanyID>87654321</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingCustomerParty>
++      <cac:PaymentMeans>
++        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
++        <cbc:PaymentID>SK-DMF-NEG-002</cbc:PaymentID>
++        <cac:PayeeFinancialAccount>
++          <cbc:ID>SK3112000000198742637541</cbc:ID>
++        </cac:PayeeFinancialAccount>
++      </cac:PaymentMeans>
++      <cac:TaxTotal>
++        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++        <cac:TaxSubtotal>
++          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
++          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++          <cac:TaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:TaxCategory>
++        </cac:TaxSubtotal>
++      </cac:TaxTotal>
++      <cac:LegalMonetaryTotal>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
++        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
++        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
++      </cac:LegalMonetaryTotal>
++      <cac:InvoiceLine>
++        <cbc:ID>1</cbc:ID>
++        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cac:Item>
++          <cbc:Name>Test service</cbc:Name>
++          <cac:ClassifiedTaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:ClassifiedTaxCategory>
++        </cac:Item>
++        <cac:Price>
++          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
++        </cac:Price>
++      </cac:InvoiceLine>
++    </Invoice>
++  </test>
++
++  <test>
++    <assert>
++      <success>SK-R-002</success>
++      <success>SK-R-003</success>
++      <warning>SK-R-004</warning>
++      <success>SK-R-005</success>
++      <success>SK-R-006</success>
++      <success>SK-R-007</success>
++    </assert>
++    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
++      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
++      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
++      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
++      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
++      <cbc:ID>SK-DMF-NEG-003</cbc:ID>
++      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
++      <cbc:DueDate>2026-08-20</cbc:DueDate>
++      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
++      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
++      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
++      <cac:AccountingSupplierParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
++            <cbc:CityName>Bratislava</cbc:CityName>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyTaxScheme>
++            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:PartyTaxScheme>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
++            <cbc:CompanyID>12345678</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingSupplierParty>
++      <cac:AccountingCustomerParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
++            <cbc:CityName>Kosice</cbc:CityName>
++            <cbc:PostalZone>040 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
++            <cbc:CompanyID>87654321</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingCustomerParty>
++      <cac:PaymentMeans>
++        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
++        <cbc:PaymentID>SK-DMF-NEG-003</cbc:PaymentID>
++        <cac:PayeeFinancialAccount>
++          <cbc:ID>SK3112000000198742637541</cbc:ID>
++        </cac:PayeeFinancialAccount>
++      </cac:PaymentMeans>
++      <cac:TaxTotal>
++        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++        <cac:TaxSubtotal>
++          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
++          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++          <cac:TaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:TaxCategory>
++        </cac:TaxSubtotal>
++      </cac:TaxTotal>
++      <cac:LegalMonetaryTotal>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
++        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
++        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
++      </cac:LegalMonetaryTotal>
++      <cac:InvoiceLine>
++        <cbc:ID>1</cbc:ID>
++        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cac:Item>
++          <cbc:Name>Test service</cbc:Name>
++          <cac:ClassifiedTaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:ClassifiedTaxCategory>
++        </cac:Item>
++        <cac:Price>
++          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
++        </cac:Price>
++      </cac:InvoiceLine>
++    </Invoice>
++  </test>
++
++  <test>
++    <assert>
++      <success>SK-R-002</success>
++      <success>SK-R-003</success>
++      <success>SK-R-004</success>
++      <warning>SK-R-005</warning>
++      <success>SK-R-006</success>
++      <success>SK-R-007</success>
++    </assert>
++    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
++      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
++      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
++      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
++      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
++      <cbc:ID>SK-DMF-NEG-004</cbc:ID>
++      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
++      <cbc:DueDate>2026-08-20</cbc:DueDate>
++      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
++      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
++      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
++      <cac:AccountingSupplierParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
++            <cbc:CityName>Bratislava</cbc:CityName>
++            <cbc:PostalZone>811 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyTaxScheme>
++            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:PartyTaxScheme>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
++            <cbc:CompanyID>12345678</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingSupplierParty>
++      <cac:AccountingCustomerParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:CityName>Kosice</cbc:CityName>
++            <cbc:PostalZone>040 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
++            <cbc:CompanyID>87654321</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingCustomerParty>
++      <cac:PaymentMeans>
++        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
++        <cbc:PaymentID>SK-DMF-NEG-004</cbc:PaymentID>
++        <cac:PayeeFinancialAccount>
++          <cbc:ID>SK3112000000198742637541</cbc:ID>
++        </cac:PayeeFinancialAccount>
++      </cac:PaymentMeans>
++      <cac:TaxTotal>
++        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++        <cac:TaxSubtotal>
++          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
++          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++          <cac:TaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:TaxCategory>
++        </cac:TaxSubtotal>
++      </cac:TaxTotal>
++      <cac:LegalMonetaryTotal>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
++        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
++        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
++      </cac:LegalMonetaryTotal>
++      <cac:InvoiceLine>
++        <cbc:ID>1</cbc:ID>
++        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cac:Item>
++          <cbc:Name>Test service</cbc:Name>
++          <cac:ClassifiedTaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:ClassifiedTaxCategory>
++        </cac:Item>
++        <cac:Price>
++          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
++        </cac:Price>
++      </cac:InvoiceLine>
++    </Invoice>
++  </test>
++
++  <test>
++    <assert>
++      <success>SK-R-002</success>
++      <success>SK-R-003</success>
++      <success>SK-R-004</success>
++      <success>SK-R-005</success>
++      <warning>SK-R-006</warning>
++      <success>SK-R-007</success>
++    </assert>
++    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
++      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
++      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
++      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
++      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
++      <cbc:ID>SK-DMF-NEG-005</cbc:ID>
++      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
++      <cbc:DueDate>2026-08-20</cbc:DueDate>
++      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
++      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
++      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
++      <cac:AccountingSupplierParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
++            <cbc:CityName>Bratislava</cbc:CityName>
++            <cbc:PostalZone>811 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyTaxScheme>
++            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:PartyTaxScheme>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
++            <cbc:CompanyID>12345678</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingSupplierParty>
++      <cac:AccountingCustomerParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
++            <cbc:PostalZone>040 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
++            <cbc:CompanyID>87654321</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingCustomerParty>
++      <cac:PaymentMeans>
++        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
++        <cbc:PaymentID>SK-DMF-NEG-005</cbc:PaymentID>
++        <cac:PayeeFinancialAccount>
++          <cbc:ID>SK3112000000198742637541</cbc:ID>
++        </cac:PayeeFinancialAccount>
++      </cac:PaymentMeans>
++      <cac:TaxTotal>
++        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++        <cac:TaxSubtotal>
++          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
++          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++          <cac:TaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:TaxCategory>
++        </cac:TaxSubtotal>
++      </cac:TaxTotal>
++      <cac:LegalMonetaryTotal>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
++        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
++        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
++      </cac:LegalMonetaryTotal>
++      <cac:InvoiceLine>
++        <cbc:ID>1</cbc:ID>
++        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cac:Item>
++          <cbc:Name>Test service</cbc:Name>
++          <cac:ClassifiedTaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:ClassifiedTaxCategory>
++        </cac:Item>
++        <cac:Price>
++          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
++        </cac:Price>
++      </cac:InvoiceLine>
++    </Invoice>
++  </test>
++
++  <test>
++    <assert>
++      <success>SK-R-002</success>
++      <success>SK-R-003</success>
++      <success>SK-R-004</success>
++      <success>SK-R-005</success>
++      <success>SK-R-006</success>
++      <warning>SK-R-007</warning>
++    </assert>
++    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
++      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
++      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
++      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
++      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
++      <cbc:ID>SK-DMF-NEG-006</cbc:ID>
++      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
++      <cbc:DueDate>2026-08-20</cbc:DueDate>
++      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
++      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
++      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
++      <cac:AccountingSupplierParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
++            <cbc:CityName>Bratislava</cbc:CityName>
++            <cbc:PostalZone>811 01</cbc:PostalZone>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyTaxScheme>
++            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:PartyTaxScheme>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
++            <cbc:CompanyID>12345678</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingSupplierParty>
++      <cac:AccountingCustomerParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
++            <cbc:CityName>Kosice</cbc:CityName>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
++            <cbc:CompanyID>87654321</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingCustomerParty>
++      <cac:PaymentMeans>
++        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
++        <cbc:PaymentID>SK-DMF-NEG-006</cbc:PaymentID>
++        <cac:PayeeFinancialAccount>
++          <cbc:ID>SK3112000000198742637541</cbc:ID>
++        </cac:PayeeFinancialAccount>
++      </cac:PaymentMeans>
++      <cac:TaxTotal>
++        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++        <cac:TaxSubtotal>
++          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
++          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++          <cac:TaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:TaxCategory>
++        </cac:TaxSubtotal>
++      </cac:TaxTotal>
++      <cac:LegalMonetaryTotal>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
++        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
++        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
++      </cac:LegalMonetaryTotal>
++      <cac:InvoiceLine>
++        <cbc:ID>1</cbc:ID>
++        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cac:Item>
++          <cbc:Name>Test service</cbc:Name>
++          <cac:ClassifiedTaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:ClassifiedTaxCategory>
++        </cac:Item>
++        <cac:Price>
++          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
++        </cac:Price>
++      </cac:InvoiceLine>
++    </Invoice>
++  </test>
++
++  <test>
++    <assert>
++      <success>SK-R-002</success>
++      <success>SK-R-003</success>
++      <success>SK-R-004</success>
++      <success>SK-R-005</success>
++      <success>SK-R-006</success>
++      <success>SK-R-007</success>
++    </assert>
++    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
++      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
++      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
++      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
++      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
++      <cbc:ID>SK-DMF-SCOPE-001</cbc:ID>
++      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
++      <cbc:DueDate>2026-08-20</cbc:DueDate>
++      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
++      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
++      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
++      <cac:AccountingSupplierParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cac:Country>
++              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyTaxScheme>
++            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:PartyTaxScheme>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
++            <cbc:CompanyID>12345678</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingSupplierParty>
++      <cac:AccountingCustomerParty>
++        <cac:Party>
++          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
++          <cac:PartyName>
++            <cbc:Name>Czech Test Buyer a.s.</cbc:Name>
++          </cac:PartyName>
++          <cac:PostalAddress>
++            <cac:Country>
++              <cbc:IdentificationCode>CZ</cbc:IdentificationCode>
++            </cac:Country>
++          </cac:PostalAddress>
++          <cac:PartyLegalEntity>
++            <cbc:RegistrationName>Czech Test Buyer a.s.</cbc:RegistrationName>
++            <cbc:CompanyID>87654321</cbc:CompanyID>
++          </cac:PartyLegalEntity>
++        </cac:Party>
++      </cac:AccountingCustomerParty>
++      <cac:PaymentMeans>
++        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
++        <cbc:PaymentID>SK-DMF-SCOPE-001</cbc:PaymentID>
++        <cac:PayeeFinancialAccount>
++          <cbc:ID>SK3112000000198742637541</cbc:ID>
++        </cac:PayeeFinancialAccount>
++      </cac:PaymentMeans>
++      <cac:TaxTotal>
++        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++        <cac:TaxSubtotal>
++          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
++          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
++          <cac:TaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:TaxCategory>
++        </cac:TaxSubtotal>
++      </cac:TaxTotal>
++      <cac:LegalMonetaryTotal>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
++        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
++        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
++      </cac:LegalMonetaryTotal>
++      <cac:InvoiceLine>
++        <cbc:ID>1</cbc:ID>
++        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
++        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
++        <cac:Item>
++          <cbc:Name>Test service</cbc:Name>
++          <cac:ClassifiedTaxCategory>
++            <cbc:ID>S</cbc:ID>
++            <cbc:Percent>20</cbc:Percent>
++            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
++          </cac:ClassifiedTaxCategory>
++        </cac:Item>
++        <cac:Price>
++          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
++        </cac:Price>
++      </cac:InvoiceLine>
++    </Invoice>
++  </test>
++
++</testSet>

--- a/rules/sch/PEPPOL-EN16931-UBL.sch
+++ b/rules/sch/PEPPOL-EN16931-UBL.sch
@@ -436,6 +436,21 @@ Last update: 2026 May release 3.0.21.
     </rule>
   </pattern>
   <!-- National rules -->
+  <!-- SLOVAKIA -->
+  <pattern>
+    <let name="SKSupplierCountry" value="upper-case(normalize-space(/*/cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode))" />
+    <let name="SKCustomerCountry" value="upper-case(normalize-space(/*/cac:AccountingCustomerParty/cac:Party/cac:PostalAddress/cac:Country/cbc:IdentificationCode))" />
+    <rule context="cac:AccountingSupplierParty/cac:Party/cac:PostalAddress[$SKSupplierCountry = 'SK' and $SKCustomerCountry = 'SK']">
+      <assert id="SK-R-002" test="cbc:StreetName" flag="warning">[SK-R-002]-For domestic Slovak transactions, BT-35 Seller street name shall be provided.</assert>
+      <assert id="SK-R-003" test="cbc:CityName" flag="warning">[SK-R-003]-For domestic Slovak transactions, BT-37 Seller city name shall be provided.</assert>
+      <assert id="SK-R-004" test="cbc:PostalZone" flag="warning">[SK-R-004]-For domestic Slovak transactions, BT-38 Seller postal code shall be provided.</assert>
+    </rule>
+    <rule context="cac:AccountingCustomerParty/cac:Party/cac:PostalAddress[$SKSupplierCountry = 'SK' and $SKCustomerCountry = 'SK']">
+      <assert id="SK-R-005" test="cbc:StreetName" flag="warning">[SK-R-005]-For domestic Slovak transactions, BT-50 Buyer street name shall be provided.</assert>
+      <assert id="SK-R-006" test="cbc:CityName" flag="warning">[SK-R-006]-For domestic Slovak transactions, BT-52 Buyer city name shall be provided.</assert>
+      <assert id="SK-R-007" test="cbc:PostalZone" flag="warning">[SK-R-007]-For domestic Slovak transactions, BT-53 Buyer postal code shall be provided.</assert>
+    </rule>
+  </pattern>
   <pattern>
     <!-- NORWAY -->
     <rule context="cac:AccountingSupplierParty/cac:Party[$supplierCountry = 'NO']">

--- a/rules/unit-UBL-SK/UBL-IN_SK-DMF.xml
+++ b/rules/unit-UBL-SK/UBL-IN_SK-DMF.xml
@@ -1,0 +1,866 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0"
+         configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+    <description>Slovak domestic invoices should provide the agreed seller and buyer address fields when BT-40 and BT-55 are both SK.</description>
+    <scope>SK-R-002</scope>
+    <scope>SK-R-003</scope>
+    <scope>SK-R-004</scope>
+    <scope>SK-R-005</scope>
+    <scope>SK-R-006</scope>
+    <scope>SK-R-007</scope>
+  </assert>
+
+  <test>
+    <assert>
+      <success>SK-R-002</success>
+      <success>SK-R-003</success>
+      <success>SK-R-004</success>
+      <success>SK-R-005</success>
+      <success>SK-R-006</success>
+      <success>SK-R-007</success>
+    </assert>
+    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>SK-DMF-POS-001</cbc:ID>
+      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
+      <cbc:DueDate>2026-08-20</cbc:DueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
+            <cbc:CityName>Bratislava</cbc:CityName>
+            <cbc:PostalZone>811 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+            <cbc:CompanyID>12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
+            <cbc:CityName>Kosice</cbc:CityName>
+            <cbc:PostalZone>040 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
+            <cbc:CompanyID>87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>SK-DMF-POS-001</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>SK3112000000198742637541</cbc:ID>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Test service</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </Invoice>
+  </test>
+
+  <test>
+    <assert>
+      <warning>SK-R-002</warning>
+      <success>SK-R-003</success>
+      <success>SK-R-004</success>
+      <success>SK-R-005</success>
+      <success>SK-R-006</success>
+      <success>SK-R-007</success>
+    </assert>
+    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>SK-DMF-NEG-001</cbc:ID>
+      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
+      <cbc:DueDate>2026-08-20</cbc:DueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:CityName>Bratislava</cbc:CityName>
+            <cbc:PostalZone>811 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+            <cbc:CompanyID>12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
+            <cbc:CityName>Kosice</cbc:CityName>
+            <cbc:PostalZone>040 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
+            <cbc:CompanyID>87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>SK-DMF-NEG-001</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>SK3112000000198742637541</cbc:ID>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Test service</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </Invoice>
+  </test>
+
+  <test>
+    <assert>
+      <success>SK-R-002</success>
+      <warning>SK-R-003</warning>
+      <success>SK-R-004</success>
+      <success>SK-R-005</success>
+      <success>SK-R-006</success>
+      <success>SK-R-007</success>
+    </assert>
+    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>SK-DMF-NEG-002</cbc:ID>
+      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
+      <cbc:DueDate>2026-08-20</cbc:DueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
+            <cbc:PostalZone>811 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+            <cbc:CompanyID>12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
+            <cbc:CityName>Kosice</cbc:CityName>
+            <cbc:PostalZone>040 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
+            <cbc:CompanyID>87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>SK-DMF-NEG-002</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>SK3112000000198742637541</cbc:ID>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Test service</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </Invoice>
+  </test>
+
+  <test>
+    <assert>
+      <success>SK-R-002</success>
+      <success>SK-R-003</success>
+      <warning>SK-R-004</warning>
+      <success>SK-R-005</success>
+      <success>SK-R-006</success>
+      <success>SK-R-007</success>
+    </assert>
+    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>SK-DMF-NEG-003</cbc:ID>
+      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
+      <cbc:DueDate>2026-08-20</cbc:DueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
+            <cbc:CityName>Bratislava</cbc:CityName>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+            <cbc:CompanyID>12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
+            <cbc:CityName>Kosice</cbc:CityName>
+            <cbc:PostalZone>040 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
+            <cbc:CompanyID>87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>SK-DMF-NEG-003</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>SK3112000000198742637541</cbc:ID>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Test service</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </Invoice>
+  </test>
+
+  <test>
+    <assert>
+      <success>SK-R-002</success>
+      <success>SK-R-003</success>
+      <success>SK-R-004</success>
+      <warning>SK-R-005</warning>
+      <success>SK-R-006</success>
+      <success>SK-R-007</success>
+    </assert>
+    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>SK-DMF-NEG-004</cbc:ID>
+      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
+      <cbc:DueDate>2026-08-20</cbc:DueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
+            <cbc:CityName>Bratislava</cbc:CityName>
+            <cbc:PostalZone>811 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+            <cbc:CompanyID>12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:CityName>Kosice</cbc:CityName>
+            <cbc:PostalZone>040 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
+            <cbc:CompanyID>87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>SK-DMF-NEG-004</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>SK3112000000198742637541</cbc:ID>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Test service</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </Invoice>
+  </test>
+
+  <test>
+    <assert>
+      <success>SK-R-002</success>
+      <success>SK-R-003</success>
+      <success>SK-R-004</success>
+      <success>SK-R-005</success>
+      <warning>SK-R-006</warning>
+      <success>SK-R-007</success>
+    </assert>
+    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>SK-DMF-NEG-005</cbc:ID>
+      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
+      <cbc:DueDate>2026-08-20</cbc:DueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
+            <cbc:CityName>Bratislava</cbc:CityName>
+            <cbc:PostalZone>811 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+            <cbc:CompanyID>12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
+            <cbc:PostalZone>040 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
+            <cbc:CompanyID>87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>SK-DMF-NEG-005</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>SK3112000000198742637541</cbc:ID>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Test service</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </Invoice>
+  </test>
+
+  <test>
+    <assert>
+      <success>SK-R-002</success>
+      <success>SK-R-003</success>
+      <success>SK-R-004</success>
+      <success>SK-R-005</success>
+      <success>SK-R-006</success>
+      <warning>SK-R-007</warning>
+    </assert>
+    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>SK-DMF-NEG-006</cbc:ID>
+      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
+      <cbc:DueDate>2026-08-20</cbc:DueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Dodavatelska 1</cbc:StreetName>
+            <cbc:CityName>Bratislava</cbc:CityName>
+            <cbc:PostalZone>811 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+            <cbc:CompanyID>12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Buyer a.s.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Odberatelska 2</cbc:StreetName>
+            <cbc:CityName>Kosice</cbc:CityName>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Buyer a.s.</cbc:RegistrationName>
+            <cbc:CompanyID>87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>SK-DMF-NEG-006</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>SK3112000000198742637541</cbc:ID>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Test service</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </Invoice>
+  </test>
+
+  <test>
+    <assert>
+      <success>SK-R-002</success>
+      <success>SK-R-003</success>
+      <success>SK-R-004</success>
+      <success>SK-R-005</success>
+      <success>SK-R-006</success>
+      <success>SK-R-007</success>
+    </assert>
+    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+      xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+      xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>SK-DMF-SCOPE-001</cbc:ID>
+      <cbc:IssueDate>2026-07-21</cbc:IssueDate>
+      <cbc:DueDate>2026-08-20</cbc:DueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>SK-DMF-TEST</cbc:BuyerReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020123456</cbc:CompanyID>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+            <cbc:CompanyID>12345678</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">1234567890135</cbc:EndpointID>
+          <cac:PartyName>
+            <cbc:Name>Czech Test Buyer a.s.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cac:Country>
+              <cbc:IdentificationCode>CZ</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Czech Test Buyer a.s.</cbc:RegistrationName>
+            <cbc:CompanyID>87654321</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>SK-DMF-SCOPE-001</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>SK3112000000198742637541</cbc:ID>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Test service</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </Invoice>
+  </test>
+
+</testSet>


### PR DESCRIPTION
The Slovak Peppol Authority would like to request the introduction of Slovak country-specific validation rules for domestic transactions within Peppol BIS Billing 3.0.

The rules shall apply only for domestic Slovak transactions:

Seller country (BT-40) = SK

Buyer country (BT-55) = SK

For invoices within this scope, the following Business Terms shall become mandatory:

BT-35 – Seller address StreetName

BT-37 – Seller address CityName

BT-38 – Seller address PostalNumber

BT-50 – Buyer address StreetName

BT-52 – Buyer address CityName

BT-53 – Buyer address PostalNumber

The rules are intended as restrictive country-specific validation rules only and will initially be introduced with warning severity.