### PR TITLE
Poacc 941 enable invoice type code 384 for slovakia sk

### DIFF
--- a/rules/buildconfig.xml
+++ b/rules/buildconfig.xml
@@ -19,6 +19,7 @@
   <testfolder>unit-UBL-SE</testfolder>
   <testfolder>unit-UBL-GR</testfolder>
   <testfolder>unit-UBL-NL</testfolder>
+  <testfolder>unit-UBL-SK</testfolder>
   <testfolder>unit-SBDH</testfolder>
 
   <!-- CII -->
@@ -26,19 +27,20 @@
   <configuration>
     <identifier>peppolbis-en16931-cen-cii</identifier>
     <title>CEN TC434 UBL</title>
-    <file path="sch/CEN-EN16931-CII.sch"/>
+    <file path="sch/CEN-EN16931-CII.sch" />
   </configuration>
 
   <configuration>
     <identifier>peppolbis-en16931-base-3.0-cii</identifier>
     <title>PEPPOL BIS Billing 3.0 (Base)</title>
-    <file path="sch/PEPPOL-EN16931-CII.sch"/>
+    <file path="sch/PEPPOL-EN16931-CII.sch" />
   </configuration>
 
   <configuration>
     <identifier>peppolbis-en16931-01-3.0-cii</identifier>
     <title>PEPPOL BIS Billing 3.0 (Profile 01)</title>
-    <declaration type="xml.uncefact">CrossIndustryInvoice::urn:fdc:peppol.eu:2017:poacc:billing:01:1.0::urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</declaration>
+    <declaration type="xml.uncefact">
+      CrossIndustryInvoice::urn:fdc:peppol.eu:2017:poacc:billing:01:1.0::urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</declaration>
     <inherit>uncefact-d16b-cii-uncoupled</inherit>
     <inherit>peppolbis-en16931-cen-cii</inherit>
     <inherit>peppolbis-en16931-base-3.0-cii</inherit>
@@ -49,31 +51,39 @@
   <configuration>
     <identifier>peppolbis-en16931-cen-ubl</identifier>
     <title>CEN TC434 UBL</title>
-    <file path="sch/CEN-EN16931-UBL.sch" infoUrl="http://docs.peppol.eu/poacc/billing/3.0/rules/{}/"/>
+    <file
+        path="sch/CEN-EN16931-UBL.sch"
+        infoUrl="http://docs.peppol.eu/poacc/billing/3.0/rules/{}/" />
   </configuration>
 
   <configuration>
     <identifier>peppolbis-en16931-base-3.0-ubl</identifier>
     <title>PEPPOL BIS Billing 3.0 (Base)</title>
-    <file path="sch/PEPPOL-EN16931-UBL.sch" infoUrl="http://docs.peppol.eu/poacc/billing/3.0/rules/{}/"/>
+    <file
+        path="sch/PEPPOL-EN16931-UBL.sch"
+        infoUrl="http://docs.peppol.eu/poacc/billing/3.0/rules/{}/" />
   </configuration>
 
   <configuration>
     <identifier>peppolbis-envelope-3.0-sbdh</identifier>
     <title>PEPPOL BIS Billing 3.0 (Envelope)</title>
-    <file path="sch/PeppolBIS-Envelope-Rules.sch"/>
+    <file path="sch/PeppolBIS-Envelope-Rules.sch" />
   </configuration>
 
   <configuration>
     <identifier>peppolbis-en16931-stylesheet-3.0-ubl</identifier>
     <title>PEPPOL BIS Billing 3.0 Stylesheet</title>
-    <stylesheet identifier="peppol-bis-billing-v3-ubl" source="../stylesheet/stylesheet-ubl.xslt" path="stylesheet/stylesheet-ubl.xslt"/>
+    <stylesheet
+        identifier="peppol-bis-billing-v3-ubl"
+        source="../stylesheet/stylesheet-ubl.xslt"
+        path="stylesheet/stylesheet-ubl.xslt" />
   </configuration>
 
   <configuration>
     <identifier>peppolbis-en16931-01-3.0-ubl-invoice</identifier>
     <title>PEPPOL BIS Billing 3.0 (Profile 01)</title>
-    <declaration type="xml.ubl">Invoice::urn:fdc:peppol.eu:2017:poacc:billing:01:1.0#urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</declaration>
+    <declaration type="xml.ubl">
+      Invoice::urn:fdc:peppol.eu:2017:poacc:billing:01:1.0#urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</declaration>
     <inherit>ubl-invoice-2.1</inherit>
     <inherit>peppolbis-en16931-cen-ubl</inherit>
     <inherit>peppolbis-en16931-base-3.0-ubl</inherit>
@@ -83,7 +93,8 @@
   <configuration>
     <identifier>peppolbis-en16931-01-3.0-ubl-creditnote</identifier>
     <title>PEPPOL BIS Billing 3.0 (Profile 01)</title>
-    <declaration type="xml.ubl">CreditNote::urn:fdc:peppol.eu:2017:poacc:billing:01:1.0#urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</declaration>
+    <declaration type="xml.ubl">
+      CreditNote::urn:fdc:peppol.eu:2017:poacc:billing:01:1.0#urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</declaration>
     <inherit>ubl-creditnote-2.1</inherit>
     <inherit>peppolbis-en16931-cen-ubl</inherit>
     <inherit>peppolbis-en16931-base-3.0-ubl</inherit>
@@ -93,7 +104,8 @@
   <configuration>
     <identifier>peppolbis-en16931-02-3.0-ubl-invoice</identifier>
     <title>PEPPOL BIS Billing 3.0 (Profile 02)</title>
-    <declaration type="xml.ubl">Invoice::urn:peppol:bis:billing_with_response#urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</declaration>
+    <declaration type="xml.ubl">
+      Invoice::urn:peppol:bis:billing_with_response#urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</declaration>
     <inherit>ubl-invoice-2.1</inherit>
     <inherit>peppolbis-en16931-cen-ubl</inherit>
     <inherit>peppolbis-en16931-base-3.0-ubl</inherit>
@@ -103,7 +115,8 @@
   <configuration>
     <identifier>peppolbis-en16931-02-3.0-ubl-creditnote</identifier>
     <title>PEPPOL BIS Billing 3.0 (Profile 02)</title>
-    <declaration type="xml.ubl">CreditNote::urn:peppol:bis:billing_with_response#urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</declaration>
+    <declaration type="xml.ubl">
+      CreditNote::urn:peppol:bis:billing_with_response#urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</declaration>
     <inherit>ubl-creditnote-2.1</inherit>
     <inherit>peppolbis-en16931-cen-ubl</inherit>
     <inherit>peppolbis-en16931-base-3.0-ubl</inherit>

--- a/rules/sch/PEPPOL-EN16931-UBL.sch
+++ b/rules/sch/PEPPOL-EN16931-UBL.sch
@@ -800,6 +800,12 @@ Last update: 2026 May release 3.0.21.
       <assert test="cac:TaxCategory/cbc:Percent[boolean(normalize-space(.))]" flag="fatal" id="DE-R-014">[DE-R-014]-If both supplier and customer are located in Germany, the element "VAT category rate" (BT-119) shall be provided.</assert>
     </rule>
   </pattern>
+  <!-- SLOVAKIA -->
+  <pattern>
+    <rule context="ubl-invoice:Invoice[$supplierCountry = 'SK' and $customerCountry = 'SK']">
+      <assert id="SK-R-001" test="not(normalize-space(cbc:InvoiceTypeCode) = '384') or cac:BillingReference" flag="warning">[SK-R-001]-If both supplier and customer are located in Slovakia, and if "Invoice type code" (BT-3) contains the code 384 (Corrected invoice), "Preceding invoice reference" (BG-3) should be provided at least once.</assert>
+    </rule>
+  </pattern>
   <!-- Restricted code lists and formatting -->
   <pattern>
     <let name="ISO3166" value="tokenize('AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS YE YT ZA ZM ZW 1A XI', '\s')" />
@@ -839,7 +845,7 @@ Last update: 2026 May release 3.0.21.
       <assert id="PEPPOL-EN16931-P0100" test="
           not($profile = ('01','02')) or (some $code in tokenize('71 80 82 84 102 218 219 326 331 380 382 383 384 386 388 393 395 553 575 623 780 817 870 875 876 877', '\s')
             satisfies normalize-space(text()) = $code)" flag="fatal">[PEPPOL-EN16931-P0100]-Invoice type code MUST be set according to the profile.</assert>
-      <assert id="PEPPOL-EN16931-P0112" test="not(normalize-space(.) = '326' or normalize-space(.) = '384') or ($supplierCountryIsDE and $customerCountryIsDE)" flag="fatal">[PEPPOL-EN16931-P0112]-Invoice type code 326 or 384 are only allowed when both buyer and seller are German organizations </assert>
+      <assert id="PEPPOL-EN16931-P0112" test="not(normalize-space(.) = '326' or normalize-space(.) = '384') or ($supplierCountryIsDE and $customerCountryIsDE) or (normalize-space(.) = '384' and $supplierCountry = 'SK' and $customerCountry = 'SK')" flag="fatal">[PEPPOL-EN16931-P0112]-Invoice type code 326 is only allowed when both buyer and seller are German organizations. Invoice type code 384 is only allowed when both buyer and seller are German or Slovak organizations.</assert>
     </rule>
 
     <rule context="cbc:CreditNoteTypeCode">

--- a/rules/unit-UBL-PEPPOL/PEPPOL-EN16931-P0112.xml
+++ b/rules/unit-UBL-PEPPOL/PEPPOL-EN16931-P0112.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="peppolbis-en16931-base-3.0-ubl">
 	<assert>
-		<description>Invoice type code 326 or 384 are only allowed when both buyer and
-        seller are German organizations.</description>
+		<description>Invoice type code 326 is only allowed when both buyer and seller are German organizations. Invoice type code 384 is only allowed when both buyer and seller are German or Slovak organizations.</description>
 		<scope>PEPPOL-EN16931-P0112</scope>
 	</assert>
 	<test>
@@ -211,6 +210,419 @@
 					</cac:PostalAddress>
 				</cac:Party>
 			</cac:AccountingCustomerParty>
+		</Invoice>
+	</test>
+	<!-- SK384-001: the contribution adds the domestic Slovak success case. -->
+	<test>
+		<assert>
+			<success>PEPPOL-EN16931-P0112</success>
+		</assert>
+		<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+		         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+		         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+		  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+		  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+		  <cbc:ID>SK384-001</cbc:ID>
+		  <cbc:IssueDate>2026-08-12</cbc:IssueDate>
+		  <cbc:DueDate>2026-09-11</cbc:DueDate>
+		  <cbc:InvoiceTypeCode>384</cbc:InvoiceTypeCode>
+		  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+		  <cbc:BuyerReference>SK-BUYER-REFERENCE-2026</cbc:BuyerReference>
+		  <cac:BillingReference>
+		    <cac:InvoiceDocumentReference>
+		      <cbc:ID>SK-ORIGINAL-2026-0001</cbc:ID>
+		    </cac:InvoiceDocumentReference>
+		  </cac:BillingReference>
+		  <cac:AccountingSupplierParty>
+		    <cac:Party>
+		      <cbc:EndpointID schemeID="0088">8580000000016</cbc:EndpointID>
+		      <cac:PartyIdentification>
+		        <cbc:ID>SK-SUPPLIER-001</cbc:ID>
+		      </cac:PartyIdentification>
+		      <cac:PartyName>
+		        <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+		      </cac:PartyName>
+		      <cac:PostalAddress>
+		        <cbc:StreetName>Mlynske nivy 12</cbc:StreetName>
+		        <cbc:CityName>Bratislava</cbc:CityName>
+		        <cbc:PostalZone>821 09</cbc:PostalZone>
+		        <cac:Country>
+		          <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+		        </cac:Country>
+		      </cac:PostalAddress>
+		      <cac:PartyTaxScheme>
+		        <cbc:CompanyID>SK2020000001</cbc:CompanyID>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:PartyTaxScheme>
+		      <cac:PartyLegalEntity>
+		        <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+		        <cbc:CompanyID>50000001</cbc:CompanyID>
+		      </cac:PartyLegalEntity>
+		      <cac:Contact>
+		        <cbc:Name>Accounts Receivable</cbc:Name>
+		        <cbc:ElectronicMail>supplier@example.sk</cbc:ElectronicMail>
+		      </cac:Contact>
+		    </cac:Party>
+		  </cac:AccountingSupplierParty>
+		  <cac:AccountingCustomerParty>
+		    <cac:Party>
+		      <cbc:EndpointID schemeID="0088">8580000000023</cbc:EndpointID>
+		      <cac:PartyIdentification>
+		        <cbc:ID>SK-CUSTOMER-001</cbc:ID>
+		      </cac:PartyIdentification>
+		      <cac:PartyName>
+		        <cbc:Name>Slovak Test Customer a.s.</cbc:Name>
+		      </cac:PartyName>
+		      <cac:PostalAddress>
+		        <cbc:StreetName>Sturova 8</cbc:StreetName>
+		        <cbc:CityName>Kosice</cbc:CityName>
+		        <cbc:PostalZone>040 01</cbc:PostalZone>
+		        <cac:Country>
+		          <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+		        </cac:Country>
+		      </cac:PostalAddress>
+		      <cac:PartyTaxScheme>
+		        <cbc:CompanyID>SK2020000002</cbc:CompanyID>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:PartyTaxScheme>
+		      <cac:PartyLegalEntity>
+		        <cbc:RegistrationName>Slovak Test Customer a.s.</cbc:RegistrationName>
+		        <cbc:CompanyID>50000002</cbc:CompanyID>
+		      </cac:PartyLegalEntity>
+		      <cac:Contact>
+		        <cbc:Name>Accounts Payable</cbc:Name>
+		        <cbc:ElectronicMail>customer@example.sk</cbc:ElectronicMail>
+		      </cac:Contact>
+		    </cac:Party>
+		  </cac:AccountingCustomerParty>
+		  <cac:Delivery>
+		    <cbc:ActualDeliveryDate>2026-08-10</cbc:ActualDeliveryDate>
+		  </cac:Delivery>
+		  <cac:PaymentMeans>
+		    <cbc:PaymentMeansCode name="Credit transfer">30</cbc:PaymentMeansCode>
+		    <cbc:PaymentID>SK384-001</cbc:PaymentID>
+		    <cac:PayeeFinancialAccount>
+		      <cbc:ID>SK3112000000198742637541</cbc:ID>
+		      <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+		    </cac:PayeeFinancialAccount>
+		  </cac:PaymentMeans>
+		  <cac:PaymentTerms>
+		    <cbc:Note>Payment due within 30 days.</cbc:Note>
+		  </cac:PaymentTerms>
+		  <cac:TaxTotal>
+		    <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+		    <cac:TaxSubtotal>
+		      <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+		      <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+		      <cac:TaxCategory>
+		        <cbc:ID>S</cbc:ID>
+		        <cbc:Percent>20</cbc:Percent>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:TaxCategory>
+		    </cac:TaxSubtotal>
+		  </cac:TaxTotal>
+		  <cac:LegalMonetaryTotal>
+		    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+		    <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+		    <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+		    <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+		  </cac:LegalMonetaryTotal>
+		  <cac:InvoiceLine>
+		    <cbc:ID>1</cbc:ID>
+		    <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+		    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+		    <cac:Item>
+		      <cbc:Name>Professional services</cbc:Name>
+		      <cac:ClassifiedTaxCategory>
+		        <cbc:ID>S</cbc:ID>
+		        <cbc:Percent>20</cbc:Percent>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:ClassifiedTaxCategory>
+		    </cac:Item>
+		    <cac:Price>
+		      <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+		    </cac:Price>
+		  </cac:InvoiceLine>
+		</Invoice>
+	</test>
+	<!-- SK384-004: cross-border code 384 remains prohibited. -->
+	<test>
+		<assert>
+			<error>PEPPOL-EN16931-P0112</error>
+		</assert>
+		<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+		         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+		         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+		  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+		  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+		  <cbc:ID>SK384-004</cbc:ID>
+		  <cbc:IssueDate>2026-08-12</cbc:IssueDate>
+		  <cbc:DueDate>2026-09-11</cbc:DueDate>
+		  <cbc:InvoiceTypeCode>384</cbc:InvoiceTypeCode>
+		  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+		  <cbc:BuyerReference>SK-BUYER-REFERENCE-2026</cbc:BuyerReference>
+		  <cac:AccountingSupplierParty>
+		    <cac:Party>
+		      <cbc:EndpointID schemeID="0088">8580000000016</cbc:EndpointID>
+		      <cac:PartyIdentification>
+		        <cbc:ID>SK-SUPPLIER-001</cbc:ID>
+		      </cac:PartyIdentification>
+		      <cac:PartyName>
+		        <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+		      </cac:PartyName>
+		      <cac:PostalAddress>
+		        <cbc:StreetName>Mlynske nivy 12</cbc:StreetName>
+		        <cbc:CityName>Bratislava</cbc:CityName>
+		        <cbc:PostalZone>821 09</cbc:PostalZone>
+		        <cac:Country>
+		          <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+		        </cac:Country>
+		      </cac:PostalAddress>
+		      <cac:PartyTaxScheme>
+		        <cbc:CompanyID>SK2020000001</cbc:CompanyID>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:PartyTaxScheme>
+		      <cac:PartyLegalEntity>
+		        <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+		        <cbc:CompanyID>50000001</cbc:CompanyID>
+		      </cac:PartyLegalEntity>
+		      <cac:Contact>
+		        <cbc:Name>Accounts Receivable</cbc:Name>
+		        <cbc:ElectronicMail>supplier@example.sk</cbc:ElectronicMail>
+		      </cac:Contact>
+		    </cac:Party>
+		  </cac:AccountingSupplierParty>
+		  <cac:AccountingCustomerParty>
+		    <cac:Party>
+		      <cbc:EndpointID schemeID="0088">4000000000020</cbc:EndpointID>
+		      <cac:PartyIdentification>
+		        <cbc:ID>DE-CUSTOMER-001</cbc:ID>
+		      </cac:PartyIdentification>
+		      <cac:PartyName>
+		        <cbc:Name>German Test Customer GmbH</cbc:Name>
+		      </cac:PartyName>
+		      <cac:PostalAddress>
+		        <cbc:StreetName>Friedrichstrasse 10</cbc:StreetName>
+		        <cbc:CityName>Berlin</cbc:CityName>
+		        <cbc:PostalZone>10117</cbc:PostalZone>
+		        <cac:Country>
+		          <cbc:IdentificationCode>DE</cbc:IdentificationCode>
+		        </cac:Country>
+		      </cac:PostalAddress>
+		      <cac:PartyTaxScheme>
+		        <cbc:CompanyID>DE123456789</cbc:CompanyID>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:PartyTaxScheme>
+		      <cac:PartyLegalEntity>
+		        <cbc:RegistrationName>German Test Customer GmbH</cbc:RegistrationName>
+		        <cbc:CompanyID>HRB 123456</cbc:CompanyID>
+		      </cac:PartyLegalEntity>
+		      <cac:Contact>
+		        <cbc:Name>Accounts Payable</cbc:Name>
+		        <cbc:ElectronicMail>customer@example.de</cbc:ElectronicMail>
+		      </cac:Contact>
+		    </cac:Party>
+		  </cac:AccountingCustomerParty>
+		  <cac:Delivery>
+		    <cbc:ActualDeliveryDate>2026-08-10</cbc:ActualDeliveryDate>
+		  </cac:Delivery>
+		  <cac:PaymentMeans>
+		    <cbc:PaymentMeansCode name="Credit transfer">30</cbc:PaymentMeansCode>
+		    <cbc:PaymentID>SK384-004</cbc:PaymentID>
+		    <cac:PayeeFinancialAccount>
+		      <cbc:ID>SK3112000000198742637541</cbc:ID>
+		      <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+		    </cac:PayeeFinancialAccount>
+		  </cac:PaymentMeans>
+		  <cac:PaymentTerms>
+		    <cbc:Note>Payment due within 30 days.</cbc:Note>
+		  </cac:PaymentTerms>
+		  <cac:TaxTotal>
+		    <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+		    <cac:TaxSubtotal>
+		      <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+		      <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+		      <cac:TaxCategory>
+		        <cbc:ID>S</cbc:ID>
+		        <cbc:Percent>20</cbc:Percent>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:TaxCategory>
+		    </cac:TaxSubtotal>
+		  </cac:TaxTotal>
+		  <cac:LegalMonetaryTotal>
+		    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+		    <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+		    <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+		    <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+		  </cac:LegalMonetaryTotal>
+		  <cac:InvoiceLine>
+		    <cbc:ID>1</cbc:ID>
+		    <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+		    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+		    <cac:Item>
+		      <cbc:Name>Professional services</cbc:Name>
+		      <cac:ClassifiedTaxCategory>
+		        <cbc:ID>S</cbc:ID>
+		        <cbc:Percent>20</cbc:Percent>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:ClassifiedTaxCategory>
+		    </cac:Item>
+		    <cac:Price>
+		      <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+		    </cac:Price>
+		  </cac:InvoiceLine>
+		</Invoice>
+	</test>
+	<!-- SK384-005: the reverse cross-border direction remains prohibited. -->
+	<test>
+		<assert>
+			<error>PEPPOL-EN16931-P0112</error>
+		</assert>
+		<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+		         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+		         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+		  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+		  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+		  <cbc:ID>SK384-005</cbc:ID>
+		  <cbc:IssueDate>2026-08-12</cbc:IssueDate>
+		  <cbc:DueDate>2026-09-11</cbc:DueDate>
+		  <cbc:InvoiceTypeCode>384</cbc:InvoiceTypeCode>
+		  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+		  <cbc:BuyerReference>SK-BUYER-REFERENCE-2026</cbc:BuyerReference>
+		  <cac:AccountingSupplierParty>
+		    <cac:Party>
+		      <cbc:EndpointID schemeID="0088">4000000000013</cbc:EndpointID>
+		      <cac:PartyIdentification>
+		        <cbc:ID>DE-SUPPLIER-001</cbc:ID>
+		      </cac:PartyIdentification>
+		      <cac:PartyName>
+		        <cbc:Name>German Test Supplier GmbH</cbc:Name>
+		      </cac:PartyName>
+		      <cac:PostalAddress>
+		        <cbc:StreetName>Hauptstrasse 20</cbc:StreetName>
+		        <cbc:CityName>Munich</cbc:CityName>
+		        <cbc:PostalZone>80331</cbc:PostalZone>
+		        <cac:Country>
+		          <cbc:IdentificationCode>DE</cbc:IdentificationCode>
+		        </cac:Country>
+		      </cac:PostalAddress>
+		      <cac:PartyTaxScheme>
+		        <cbc:CompanyID>DE987654321</cbc:CompanyID>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:PartyTaxScheme>
+		      <cac:PartyLegalEntity>
+		        <cbc:RegistrationName>German Test Supplier GmbH</cbc:RegistrationName>
+		        <cbc:CompanyID>HRB 654321</cbc:CompanyID>
+		      </cac:PartyLegalEntity>
+		      <cac:Contact>
+		        <cbc:Name>Accounts Receivable</cbc:Name>
+		        <cbc:ElectronicMail>supplier@example.de</cbc:ElectronicMail>
+		      </cac:Contact>
+		    </cac:Party>
+		  </cac:AccountingSupplierParty>
+		  <cac:AccountingCustomerParty>
+		    <cac:Party>
+		      <cbc:EndpointID schemeID="0088">8580000000023</cbc:EndpointID>
+		      <cac:PartyIdentification>
+		        <cbc:ID>SK-CUSTOMER-001</cbc:ID>
+		      </cac:PartyIdentification>
+		      <cac:PartyName>
+		        <cbc:Name>Slovak Test Customer a.s.</cbc:Name>
+		      </cac:PartyName>
+		      <cac:PostalAddress>
+		        <cbc:StreetName>Sturova 8</cbc:StreetName>
+		        <cbc:CityName>Kosice</cbc:CityName>
+		        <cbc:PostalZone>040 01</cbc:PostalZone>
+		        <cac:Country>
+		          <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+		        </cac:Country>
+		      </cac:PostalAddress>
+		      <cac:PartyTaxScheme>
+		        <cbc:CompanyID>SK2020000002</cbc:CompanyID>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:PartyTaxScheme>
+		      <cac:PartyLegalEntity>
+		        <cbc:RegistrationName>Slovak Test Customer a.s.</cbc:RegistrationName>
+		        <cbc:CompanyID>50000002</cbc:CompanyID>
+		      </cac:PartyLegalEntity>
+		      <cac:Contact>
+		        <cbc:Name>Accounts Payable</cbc:Name>
+		        <cbc:ElectronicMail>customer@example.sk</cbc:ElectronicMail>
+		      </cac:Contact>
+		    </cac:Party>
+		  </cac:AccountingCustomerParty>
+		  <cac:Delivery>
+		    <cbc:ActualDeliveryDate>2026-08-10</cbc:ActualDeliveryDate>
+		  </cac:Delivery>
+		  <cac:PaymentMeans>
+		    <cbc:PaymentMeansCode name="Credit transfer">30</cbc:PaymentMeansCode>
+		    <cbc:PaymentID>SK384-005</cbc:PaymentID>
+		    <cac:PayeeFinancialAccount>
+		      <cbc:ID>SK3112000000198742637541</cbc:ID>
+		      <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+		    </cac:PayeeFinancialAccount>
+		  </cac:PaymentMeans>
+		  <cac:PaymentTerms>
+		    <cbc:Note>Payment due within 30 days.</cbc:Note>
+		  </cac:PaymentTerms>
+		  <cac:TaxTotal>
+		    <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+		    <cac:TaxSubtotal>
+		      <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+		      <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+		      <cac:TaxCategory>
+		        <cbc:ID>S</cbc:ID>
+		        <cbc:Percent>20</cbc:Percent>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:TaxCategory>
+		    </cac:TaxSubtotal>
+		  </cac:TaxTotal>
+		  <cac:LegalMonetaryTotal>
+		    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+		    <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+		    <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+		    <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+		  </cac:LegalMonetaryTotal>
+		  <cac:InvoiceLine>
+		    <cbc:ID>1</cbc:ID>
+		    <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+		    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+		    <cac:Item>
+		      <cbc:Name>Professional services</cbc:Name>
+		      <cac:ClassifiedTaxCategory>
+		        <cbc:ID>S</cbc:ID>
+		        <cbc:Percent>20</cbc:Percent>
+		        <cac:TaxScheme>
+		          <cbc:ID>VAT</cbc:ID>
+		        </cac:TaxScheme>
+		      </cac:ClassifiedTaxCategory>
+		    </cac:Item>
+		    <cac:Price>
+		      <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+		    </cac:Price>
+		  </cac:InvoiceLine>
 		</Invoice>
 	</test>
 </testSet>

--- a/rules/unit-UBL-SK/UBL-IN_SK-R-001.xml
+++ b/rules/unit-UBL-SK/UBL-IN_SK-R-001.xml
@@ -1,0 +1,424 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0"
+         configuration="peppolbis-en16931-base-3.0-ubl">
+  <assert>
+    <description>SK-R-001 requires a preceding invoice reference for Invoice Type Code 384 when both supplier and customer are Slovak.</description>
+    <scope>SK-R-001</scope>
+  </assert>
+
+  <!-- SK384-001: domestic code 384 with BG-3 must pass. -->
+  <test>
+    <assert>
+      <success>SK-R-001</success>
+    </assert>
+    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+             xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+             xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>SK384-001</cbc:ID>
+      <cbc:IssueDate>2026-08-12</cbc:IssueDate>
+      <cbc:DueDate>2026-09-11</cbc:DueDate>
+      <cbc:InvoiceTypeCode>384</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>SK-BUYER-REFERENCE-2026</cbc:BuyerReference>
+      <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+          <cbc:ID>SK-ORIGINAL-2026-0001</cbc:ID>
+        </cac:InvoiceDocumentReference>
+      </cac:BillingReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">8580000000016</cbc:EndpointID>
+          <cac:PartyIdentification>
+            <cbc:ID>SK-SUPPLIER-001</cbc:ID>
+          </cac:PartyIdentification>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Mlynske nivy 12</cbc:StreetName>
+            <cbc:CityName>Bratislava</cbc:CityName>
+            <cbc:PostalZone>821 09</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020000001</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+            <cbc:CompanyID>50000001</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Accounts Receivable</cbc:Name>
+            <cbc:ElectronicMail>supplier@example.sk</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">8580000000023</cbc:EndpointID>
+          <cac:PartyIdentification>
+            <cbc:ID>SK-CUSTOMER-001</cbc:ID>
+          </cac:PartyIdentification>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Customer a.s.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Sturova 8</cbc:StreetName>
+            <cbc:CityName>Kosice</cbc:CityName>
+            <cbc:PostalZone>040 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020000002</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Customer a.s.</cbc:RegistrationName>
+            <cbc:CompanyID>50000002</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Accounts Payable</cbc:Name>
+            <cbc:ElectronicMail>customer@example.sk</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2026-08-10</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode name="Credit transfer">30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>SK384-001</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>SK3112000000198742637541</cbc:ID>
+          <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment due within 30 days.</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Professional services</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </Invoice>
+  </test>
+
+  <!-- SK384-002: domestic code 384 without BG-3 must produce the warning. -->
+  <test>
+    <assert>
+      <warning>SK-R-001</warning>
+    </assert>
+    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+             xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+             xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>SK384-002</cbc:ID>
+      <cbc:IssueDate>2026-08-12</cbc:IssueDate>
+      <cbc:DueDate>2026-09-11</cbc:DueDate>
+      <cbc:InvoiceTypeCode>384</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>SK-BUYER-REFERENCE-2026</cbc:BuyerReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">8580000000016</cbc:EndpointID>
+          <cac:PartyIdentification>
+            <cbc:ID>SK-SUPPLIER-001</cbc:ID>
+          </cac:PartyIdentification>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Mlynske nivy 12</cbc:StreetName>
+            <cbc:CityName>Bratislava</cbc:CityName>
+            <cbc:PostalZone>821 09</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020000001</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+            <cbc:CompanyID>50000001</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Accounts Receivable</cbc:Name>
+            <cbc:ElectronicMail>supplier@example.sk</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">8580000000023</cbc:EndpointID>
+          <cac:PartyIdentification>
+            <cbc:ID>SK-CUSTOMER-001</cbc:ID>
+          </cac:PartyIdentification>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Customer a.s.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Sturova 8</cbc:StreetName>
+            <cbc:CityName>Kosice</cbc:CityName>
+            <cbc:PostalZone>040 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020000002</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Customer a.s.</cbc:RegistrationName>
+            <cbc:CompanyID>50000002</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Accounts Payable</cbc:Name>
+            <cbc:ElectronicMail>customer@example.sk</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2026-08-10</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode name="Credit transfer">30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>SK384-002</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>SK3112000000198742637541</cbc:ID>
+          <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment due within 30 days.</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Professional services</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </Invoice>
+  </test>
+
+  <!-- SK384-003: another invoice type must not trigger the rule. -->
+  <test>
+    <assert>
+      <success>SK-R-001</success>
+    </assert>
+    <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+             xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+             xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+      <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+      <cbc:ID>SK384-003</cbc:ID>
+      <cbc:IssueDate>2026-08-12</cbc:IssueDate>
+      <cbc:DueDate>2026-09-11</cbc:DueDate>
+      <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+      <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+      <cbc:BuyerReference>SK-BUYER-REFERENCE-2026</cbc:BuyerReference>
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">8580000000016</cbc:EndpointID>
+          <cac:PartyIdentification>
+            <cbc:ID>SK-SUPPLIER-001</cbc:ID>
+          </cac:PartyIdentification>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Mlynske nivy 12</cbc:StreetName>
+            <cbc:CityName>Bratislava</cbc:CityName>
+            <cbc:PostalZone>821 09</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020000001</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Supplier s.r.o.</cbc:RegistrationName>
+            <cbc:CompanyID>50000001</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Accounts Receivable</cbc:Name>
+            <cbc:ElectronicMail>supplier@example.sk</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+      <cac:AccountingCustomerParty>
+        <cac:Party>
+          <cbc:EndpointID schemeID="0088">8580000000023</cbc:EndpointID>
+          <cac:PartyIdentification>
+            <cbc:ID>SK-CUSTOMER-001</cbc:ID>
+          </cac:PartyIdentification>
+          <cac:PartyName>
+            <cbc:Name>Slovak Test Customer a.s.</cbc:Name>
+          </cac:PartyName>
+          <cac:PostalAddress>
+            <cbc:StreetName>Sturova 8</cbc:StreetName>
+            <cbc:CityName>Kosice</cbc:CityName>
+            <cbc:PostalZone>040 01</cbc:PostalZone>
+            <cac:Country>
+              <cbc:IdentificationCode>SK</cbc:IdentificationCode>
+            </cac:Country>
+          </cac:PostalAddress>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID>SK2020000002</cbc:CompanyID>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:PartyTaxScheme>
+          <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Slovak Test Customer a.s.</cbc:RegistrationName>
+            <cbc:CompanyID>50000002</cbc:CompanyID>
+          </cac:PartyLegalEntity>
+          <cac:Contact>
+            <cbc:Name>Accounts Payable</cbc:Name>
+            <cbc:ElectronicMail>customer@example.sk</cbc:ElectronicMail>
+          </cac:Contact>
+        </cac:Party>
+      </cac:AccountingCustomerParty>
+      <cac:Delivery>
+        <cbc:ActualDeliveryDate>2026-08-10</cbc:ActualDeliveryDate>
+      </cac:Delivery>
+      <cac:PaymentMeans>
+        <cbc:PaymentMeansCode name="Credit transfer">30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>SK384-003</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+          <cbc:ID>SK3112000000198742637541</cbc:ID>
+          <cbc:Name>Slovak Test Supplier s.r.o.</cbc:Name>
+        </cac:PayeeFinancialAccount>
+      </cac:PaymentMeans>
+      <cac:PaymentTerms>
+        <cbc:Note>Payment due within 30 days.</cbc:Note>
+      </cac:PaymentTerms>
+      <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+          <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">20.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:TaxCategory>
+        </cac:TaxSubtotal>
+      </cac:TaxTotal>
+      <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">120.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">120.00</cbc:PayableAmount>
+      </cac:LegalMonetaryTotal>
+      <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+          <cbc:Name>Professional services</cbc:Name>
+          <cac:ClassifiedTaxCategory>
+            <cbc:ID>S</cbc:ID>
+            <cbc:Percent>20</cbc:Percent>
+            <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+          </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+          <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+      </cac:InvoiceLine>
+    </Invoice>
+  </test>
+</testSet>


### PR DESCRIPTION
Add the check to use invoicetypecode 384 for Slovakia.
This code can also be used in Germany.
Invoicetypecode 326 is also allowed in Germany, but not in Slovakia.